### PR TITLE
contrib/cray: wrap fabtest script

### DIFF
--- a/contrib/cray/Jenkinsfile.verbs
+++ b/contrib/cray/Jenkinsfile.verbs
@@ -70,8 +70,7 @@ pipeline {
                     steps {
                         timeout (time: 20, unit: 'MINUTES') {
                             script {
-                                def command = '$FABTEST_PATH/bin/runfabtests.sh -p $FABTEST_PATH/bin -v -T 60 \'ofi_rxm;verbs\' 10.0.0.7 10.0.0.8'
-                                launch "$command", 1, 1, 'cn8'
+                                launch 'contrib/cray/fabtest_wrapper.sh', 2, 1
                             }
                         }
                     }

--- a/contrib/cray/fabtest_wrapper.sh
+++ b/contrib/cray/fabtest_wrapper.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+export FABTESTS_PATH=/scratch/jenkins/builds/fabtests/stable
+export PATH=${FABTESTS_PATH}/bin:$PATH
+
+if [[ -z ${FABTEST_PROVIDER} ]] ; then
+    FABTEST_PROVIDER='verbs;ofi_rxm'
+fi
+
+if [[ -z ${SLURMD_NODENAME} ]] ; then
+    echo SLURM is the only supported WLM at this point for testing
+    exit 1
+fi
+
+SERVER=$(scontrol show hostname ${SLURM_NODELIST} | head -n1)
+CLIENT=$(scontrol show hostname ${SLURM_NODELIST} | tail -n1)
+
+
+
+SERVER_ADDR=$(getent hosts ${SERVER} | awk '{print $1}')
+CLIENT_ADDR=$(getent hosts ${CLIENT} | awk '{print $1}')
+
+if [[ "${SLURMD_NODENAME}" == "$SERVER" ]] ; then
+    runfabtests.sh -p ${FABTESTS_PATH}/bin -v -T 60 "${FABTEST_PROVIDER}" ${SERVER_ADDR} ${CLIENT_ADDR}
+fi


### PR DESCRIPTION
Wrap the fabtest script so it can be run client/server on any arbitrary set of nodes

Signed-off-by: James Swaro <jswaro@cray.com>