### PR TITLE
prov/rxm: Make sure cmap attribute cleanup function pointer is set or i…

### DIFF
--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -734,6 +734,7 @@ struct util_cmap *rxm_conn_cmap_alloc(struct rxm_ep *rxm_ep)
 
 	if (rxm_ep->util_ep.domain->data_progress == FI_PROGRESS_AUTO) {
 		attr.cm_thread_func = rxm_conn_progress;
+		attr.cleanup = NULL;
 	} else {
 		attr.cm_thread_func = rxm_conn_eq_read;
 		attr.cleanup = rxm_conn_cleanup;


### PR DESCRIPTION
…s NULL.

I was seeing segmentation faults because cmap attributes cleanup function pointer
was uninitialized.

Signed-off-by: Steve Welch <swelch@systemfabricworks.com>