### PR TITLE
contrib/cray: Return exit value of test

### DIFF
--- a/contrib/cray/bin/logwrap
+++ b/contrib/cray/bin/logwrap
@@ -35,5 +35,5 @@ if [[ $# -eq 0 ]] ; then
     exit 1
 fi
 
-$@ | tee $OUTFILE
-exit $?
+$@ 2>&1 | tee $OUTFILE
+exit ${PIPESTATUS[0]}


### PR DESCRIPTION
In the logwrap script, the exit value of tee was being returned
rather than the status of the first command. This commit addresses
this issue by returning the pipestatus of command 0.

Signed-off-by: James Swaro <jswaro@cray.com>