### PR TITLE
prov/verbs: Initial experimental XRC EP_MSG implementation.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -81,6 +81,15 @@ AC_ARG_ENABLE([direct],
 	[],
 	[enable_direct=no])
 
+AC_ARG_WITH([verbs-xrc],
+    AC_HELP_STRING([--with-verbs-xrc],
+		   [Enable Verbs XRC transport support @<:@default=no@:>@]))
+
+if test "$with_verbs_xrc" != "" && test "$with_verbs_xrc" != "no"; then
+	AC_DEFINE([INCLUDE_VERBS_XRC], 1,
+		  [Define to 1 to enable Verbs XRC transport support])
+fi
+
 dnl Checks for programs
 AC_PROG_CC_C99
 AM_PROG_CC_C_O

--- a/prov/verbs/Makefile.include
+++ b/prov/verbs/Makefile.include
@@ -1,17 +1,19 @@
 if HAVE_VERBS
-_verbs_files =					\
-	prov/verbs/src/fi_verbs.h		\
-	prov/verbs/src/fi_verbs.c		\
-	prov/verbs/src/verbs_cm.c		\
-	prov/verbs/src/verbs_cq.c		\
-	prov/verbs/src/verbs_domain.c		\
-	prov/verbs/src/verbs_mr.c		\
-	prov/verbs/src/verbs_eq.c		\
-	prov/verbs/src/verbs_info.c		\
-	prov/verbs/src/verbs_ep.c		\
-	prov/verbs/src/verbs_msg.c		\
-	prov/verbs/src/verbs_rma.c		\
-	prov/verbs/src/verbs_dgram_ep_msg.c	\
+_verbs_files =							\
+	prov/verbs/src/fi_verbs.h				\
+	prov/verbs/src/fi_verbs.c				\
+	prov/verbs/src/verbs_cm.c				\
+	prov/verbs/src/verbs_cm_xrc.c				\
+	prov/verbs/src/verbs_cq.c				\
+	prov/verbs/src/verbs_domain.c				\
+	prov/verbs/src/verbs_domain_xrc.c			\
+	prov/verbs/src/verbs_mr.c				\
+	prov/verbs/src/verbs_eq.c				\
+	prov/verbs/src/verbs_info.c				\
+	prov/verbs/src/verbs_ep.c				\
+	prov/verbs/src/verbs_msg.c				\
+	prov/verbs/src/verbs_rma.c				\
+	prov/verbs/src/verbs_dgram_ep_msg.c			\
 	prov/verbs/src/verbs_dgram_av.c
 
 if HAVE_VERBS_DL

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -64,6 +64,13 @@ struct fi_ibv_gl_data fi_ibv_gl_data = {
 		.use_name_server	= 1,
 		.name_server_port	= 5678,
 	},
+
+	.msg			= {
+		/* Disabled by default. Use XRC transport for message
+		 * endpoint only if it is explicitly requested */
+		.use_xrc		= 0,
+		.xrcd_filename		= "/tmp/verbs_xrcd",
+	},
 };
 
 struct fi_ibv_dev_preset {
@@ -311,7 +318,7 @@ int fi_ibv_set_rnr_timer(struct ibv_qp *qp)
 }
 
 int fi_ibv_find_max_inline(struct ibv_pd *pd, struct ibv_context *context,
-                           enum ibv_qp_type qp_type)
+			   enum ibv_qp_type qp_type)
 {
 	struct ibv_qp_init_attr qp_attr;
 	struct ibv_qp *qp = NULL;
@@ -332,12 +339,14 @@ int fi_ibv_find_max_inline(struct ibv_pd *pd, struct ibv_context *context,
 
 	memset(&qp_attr, 0, sizeof(qp_attr));
 	qp_attr.send_cq = cq;
-	qp_attr.recv_cq = cq;
 	qp_attr.qp_type = qp_type;
 	qp_attr.cap.max_send_wr = 1;
-	qp_attr.cap.max_recv_wr = 1;
 	qp_attr.cap.max_send_sge = 1;
-	qp_attr.cap.max_recv_sge = 1;
+	if (qp_type != IBV_QPT_XRC_SEND) {
+		qp_attr.recv_cq = cq;
+		qp_attr.cap.max_recv_wr = 1;
+		qp_attr.cap.max_recv_sge = 1;
+	}
 	qp_attr.sq_sig_all = 1;
 
 	do {
@@ -535,6 +544,30 @@ static int fi_ibv_read_params(void)
 				  &fi_ibv_gl_data.use_odp)) {
 		VERBS_WARN(FI_LOG_CORE,
 			   "Invalid value of use_odp\n");
+		return -FI_EINVAL;
+	}
+
+	if (fi_ibv_get_param_bool("use_xrc", "Enable XRC transport for message "
+				  "endpoint. XRC is under development.",
+				  &fi_ibv_gl_data.msg.use_xrc)) {
+		VERBS_WARN(FI_LOG_CORE,
+			   "Invalid value of use_xrc\n");
+		return -FI_EINVAL;
+	}
+
+#ifndef INCLUDE_VERBS_XRC
+	if (fi_ibv_gl_data.msg.use_xrc) {
+		VERBS_WARN(FI_LOG_CORE, "XRC requested, but not enabled, "
+			   "configure with --with-verbs-xrc\n");
+		fi_ibv_gl_data.msg.use_xrc = 0;
+	}
+#endif
+
+	if (fi_ibv_get_param_str("xrcd_filename", "A file to "
+				 "associate with the XRC domain.",
+				 &fi_ibv_gl_data.msg.xrcd_filename)) {
+		VERBS_WARN(FI_LOG_CORE,
+			   "Invalid value of xrcd_filename\n");
 		return -FI_EINVAL;
 	}
 	if (fi_ibv_get_param_int("cqread_bunch_size", "The number of entries to "

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -69,6 +69,8 @@
 #include "ofi_list.h"
 #include "ofi_signal.h"
 #include "ofi_util.h"
+#include "ofi_tree.h"
+#include "ofi_indexer.h"
 
 #ifdef HAVE_VERBS_EXP_H
 #include <infiniband/verbs_exp.h>
@@ -110,7 +112,9 @@
 
 #define VERBS_NO_COMP_FLAG	((uint64_t)-1)
 
-#define VERBS_CM_DATA_SIZE	(56 - sizeof(struct fi_ibv_cm_data_hdr))
+#define FI_IBV_CM_DATA_SIZE	(56)
+#define VERBS_CM_DATA_SIZE	(FI_IBV_CM_DATA_SIZE -		\
+				 sizeof(struct fi_ibv_cm_data_hdr))
 
 #define VERBS_DGRAM_MSG_PREFIX_SIZE	(40)
 
@@ -168,6 +172,11 @@ extern struct fi_ibv_gl_data {
 		int	use_name_server;
 		int	name_server_port;
 	} dgram;
+
+	struct {
+		int	use_xrc;
+		char	*xrcd_filename;
+	} msg;
 } fi_ibv_gl_data;
 
 struct verbs_addr {
@@ -228,6 +237,7 @@ struct verbs_dev_info {
 	struct dlist_entry addrs;
 };
 
+
 struct fi_ibv_fabric {
 	struct util_fabric	util_fabric;
 	const struct fi_info	*info;
@@ -247,6 +257,11 @@ struct fi_ibv_eq_entry {
 
 typedef int (*fi_ibv_trywait_func)(struct fid *fid);
 
+/* The number of valid OFI indexer bits in the connection key used during
+ * XRC connection establishment. Note that only the lower 32-bits of the
+ * key are exchanged, so this value must be kept below 32-bits. */
+#define VERBS_TAG_INDEX_BITS	18
+
 struct fi_ibv_eq {
 	struct fid_eq		eq_fid;
 	struct fi_ibv_fabric	*fab;
@@ -256,6 +271,19 @@ struct fi_ibv_eq {
 	uint64_t		flags;
 	struct fi_eq_err_entry	err;
 	int			epfd;
+
+	/* The connection key map is used during the XRC connection process
+	 * to map an XRC reciprocal connection request back to the active
+	 * endpoint that initiated the original connection request. */
+	fastlock_t		xrc_idx_lock;
+	struct ofi_key_idx	conn_key_idx;
+	struct indexer		*conn_key_map;
+
+	/* TODO: This is limiting and restricts applications to using a single
+	 * listener per EQ. While sufficient for RXM we should consider using
+	 * an internal PEP listener for handling the internally processed
+	 * reciprocal connections. */
+	uint16_t		pep_port;
 };
 
 int fi_ibv_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
@@ -285,6 +313,16 @@ typedef int(*fi_ibv_mr_dereg_cb)(struct fi_ibv_mem_desc *md);
 
 struct fi_ibv_mem_notifier;
 
+struct fi_ibv_xrc_domain {
+	int				xrcd_fd;
+	struct ibv_xrcd			*xrcd;
+
+	/* The domain maintains a RBTree for mapping an endpoint destination
+	 * addresses to physical XRC INI QP connected to that host. */
+	fastlock_t			ini_mgmt_lock;
+	struct ofi_rbmap		*ini_conn_rbmap;
+};
+
 struct fi_ibv_domain {
 	struct util_domain		util_domain;
 	struct ibv_context		*verbs;
@@ -296,6 +334,10 @@ struct fi_ibv_domain {
 	struct fi_ibv_eq		*eq;
 	uint64_t			eq_flags;
 
+	/* Indicates that MSG endpoints should use the XRC transport */
+	int				use_xrc;
+	struct fi_ibv_xrc_domain	xrc;
+
 	/* MR stuff */
 	int				use_odp;
 	struct ofi_mr_cache		cache;
@@ -305,6 +347,9 @@ struct fi_ibv_domain {
 	struct fi_ibv_mem_notifier	*notifier;
 };
 
+struct fi_ibv_ep;
+struct fi_ibv_domain *fi_ibv_msg_ep_to_domain(struct fi_ibv_ep *ep);
+
 struct fi_ibv_cq;
 typedef void (*fi_ibv_cq_read_entry)(struct ibv_wc *wc, void *buf);
 
@@ -313,6 +358,7 @@ struct fi_ibv_wce {
 	struct ibv_wc		wc;
 };
 
+struct fi_ibv_srq_ep;
 struct fi_ibv_cq {
 	struct util_cq		util_cq;
 	struct ibv_comp_channel	*channel;
@@ -327,6 +373,9 @@ struct fi_ibv_cq {
 	fi_ibv_trywait_func	trywait;
 	ofi_atomic32_t		nevents;
 	struct util_buf_pool	*wce_pool;
+
+	/* The IB XRC SRQ context associated with this CQ */
+	struct fi_ibv_srq_ep	*xrc_srq_ep;
 };
 
 int fi_ibv_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
@@ -394,33 +443,169 @@ void fi_ibv_monitor_unsubscribe(struct ofi_mem_monitor *notifier,
 				struct ofi_subscription *subscription);
 struct ofi_subscription *fi_ibv_monitor_get_event(struct ofi_mem_monitor *notifier);
 
+/*
+ * An XRC SRQ cannot be created until the associated RX CQ is known,
+ * maintain a list of validated pre-posted receives to post once
+ * the SRQ is created.
+ */
+struct fi_ibv_xrc_srx_prepost {
+	struct slist_entry	prepost_entry;
+	void			*buf;
+	void			*desc;
+	void			*context;
+	size_t			len;
+	fi_addr_t		src_addr;
+};
+
 struct fi_ibv_srq_ep {
 	struct fid_ep		ep_fid;
 	struct ibv_srq		*srq;
+	struct fi_ibv_domain	*domain;
+
+	/* Due to XRC SRQ semantics, an XRC SRX context may only be bound
+	 * to multiple endpoints when they share the same RX CQ. */
+	struct fi_ibv_cq	*srq_cq;
+
+	/* XRC SRQ is not created until endpoint enable */
+	fastlock_t		prepost_lock;
+	ofi_fastlock_acquire_t	pp_fastlock_acquire;
+	ofi_fastlock_release_t	pp_fastlock_release;
+
+	struct slist		prepost_list;
+	uint32_t		max_recv_wr;
+	uint32_t		max_sge;
+	uint32_t		prepost_count;
 };
 
 int fi_ibv_srq_context(struct fid_domain *domain, struct fi_rx_attr *attr,
 		       struct fid_ep **rx_ep, void *context);
 
+/* Used to determine if XRC has been enabled and requested */
+#ifdef INCLUDE_VERBS_XRC
+static inline int fi_ibv_using_xrc(void)
+{
+	return fi_ibv_gl_data.msg.use_xrc;
+}
+
+#else /* INCLUDE_VERBS_XRC */
+static inline int fi_ibv_using_xrc(void)
+{
+	return 0;
+}
+#endif /* INCLUDE_VERBS_XRC */
+
+int fi_ibv_domain_xrc_init(struct fi_ibv_domain *domain);
+int fi_ibv_domain_xrc_cleanup(struct fi_ibv_domain *domain);
+
+enum fi_ibv_ini_qp_state {
+	FI_IBV_INI_QP_UNCONNECTED,
+	FI_IBV_INI_QP_CONNECTING,
+	FI_IBV_INI_QP_CONNECTED
+};
+
+#define FI_IBV_NO_INI_TGT_QPNUM 0
+#define FI_IBV_RECIP_CONN	1
+
+/*
+ * An XRC transport INI QP connection can be shared within a process to
+ * communicate with all the ranks on the same remote node. This structure is
+ * only accessed during connection setup and tear down and should be
+ * done while holding the domain:xrc:ini_mgmt_lock.
+ */
+struct fi_ibv_ini_shared_conn {
+	/* To share, EP must have same remote peer host addr and TX CQ */
+	struct sockaddr			*peer_addr;
+	struct fi_ibv_cq		*tx_cq;
+
+	/* The physical INI/TGT QPN connection. Virtual connections to the
+	 * same remote peer and TGT QPN will share this connection, with
+	 * the remote end opening the specified XRC TGT QPN for sharing. */
+	enum fi_ibv_ini_qp_state	state;
+	struct ibv_qp			*ini_qp;
+	uint32_t			tgt_qpn;
+
+	/* EP waiting on or using this INI/TGT physical connection will be in
+	 * one of these list and hold a reference to the shared connection. */
+	struct dlist_entry		pending_list;
+	struct dlist_entry		active_list;
+	ofi_atomic32_t			ref_cnt;
+};
+
+enum fi_ibv_xrc_ep_conn_state {
+	FI_IBV_XRC_UNCONNECTED,
+	FI_IBV_XRC_ORIG_CONNECTING,
+	FI_IBV_XRC_ORIG_CONNECTED,
+	FI_IBV_XRC_RECIP_CONNECTING,
+	FI_IBV_XRC_CONNECTED
+};
+
+/*
+ * The following XRC state is only required during XRC connection
+ * establishment and can be freed once bidirectional connectivity
+ * is established.
+ */
+struct fi_ibv_xrc_ep_conn_setup {
+	uint32_t			tag;
+
+	/* IB CM message stale/duplicate detection processing requires
+	 * that shared INI/TGT connections use unique QP numbers during
+	 * RDMA CM connection setup. To avoid conflicts with actual HCA
+	 * QP number space, we allocate minimal QP that are left in the
+	 * reset state and closed once the setup process completes. */
+	struct ibv_qp			*rsvd_ini_qpn;
+	struct ibv_qp			*rsvd_tgt_qpn;
+
+
+	/* Delivery of the FI_CONNECTED event is delayed until
+	 * bidirectional connectivity is established. */
+	size_t				event_len;
+	uint8_t				event_data[FI_IBV_CM_DATA_SIZE];
+
+	/* Connection request may have to queue waiting for the
+	 * physical XRC INI/TGT QP connection to complete. */
+	int				pending_recip;
+	size_t				pending_paramlen;
+	uint8_t				pending_param[FI_IBV_CM_DATA_SIZE];
+};
+
 struct fi_ibv_ep {
-	struct util_ep		util_ep;
-	struct ibv_qp		*ibv_qp;
+	struct util_ep			util_ep;
+	struct ibv_qp			*ibv_qp;
 	union {
-		struct rdma_cm_id	*id;
+		struct rdma_cm_id		*id;
 		struct {
 			struct ofi_ib_ud_ep_name	ep_name;
 			int				service;
 		};
 	};
-	struct fi_ibv_eq	*eq;
-	struct fi_ibv_srq_ep	*srq_ep;
-	struct fi_info		*info;
+	struct fi_ibv_eq		*eq;
+	struct fi_ibv_srq_ep		*srq_ep;
+	struct fi_info			*info;
 
 	struct {
 		struct ibv_send_wr	rma_wr;
 		struct ibv_send_wr	msg_wr;
-		struct ibv_sge		sge;	
+		struct ibv_sge		sge;
 	} *wrs;
+
+#ifdef INCLUDE_VERBS_XRC
+	/* XRC only fields */
+	struct rdma_cm_id		*tgt_id;
+	struct ibv_qp			*tgt_ibv_qp;
+	enum fi_ibv_xrc_ep_conn_state	conn_state;
+	struct fi_info			*tgt_info;
+	uint32_t			srqn;
+	uint32_t			peer_srqn;
+
+	/* A reference is held to a shared physical XRC INI/TGT QP connecting
+	 * to the destination node. */
+	struct fi_ibv_ini_shared_conn	*ini_conn;
+	struct dlist_entry		ini_conn_entry;
+
+	/* The following state is allocated during XRC bidirectional setup and
+	 * freed once the connection is established. */
+	struct fi_ibv_xrc_ep_conn_setup	*conn_setup;
+#endif /* INCLUDE_VERBS_XRC */
 };
 
 int fi_ibv_open_ep(struct fid_domain *domain, struct fi_info *info,
@@ -436,21 +621,93 @@ int fi_ibv_dgram_av_open(struct fid_domain *domain_fid, struct fi_av_attr *attr,
 
 struct fi_ops_atomic fi_ibv_msg_ep_atomic_ops;
 struct fi_ops_cm fi_ibv_msg_ep_cm_ops;
+struct fi_ops_cm fi_ibv_msg_xrc_ep_cm_ops;
 struct fi_ops_msg fi_ibv_msg_ep_msg_ops_ts;
 struct fi_ops_msg fi_ibv_msg_ep_msg_ops;
 struct fi_ops_rma fi_ibv_msg_ep_rma_ops_ts;
 struct fi_ops_rma fi_ibv_msg_ep_rma_ops;
 struct fi_ops_msg fi_ibv_msg_srq_ep_msg_ops;
+struct fi_ops_msg fi_ibv_msg_xrc_srq_ep_msg_ops;
+
+#define FI_IBV_XRC_VERSION	1
+
+struct fi_ibv_xrc_cm_data {
+	uint8_t		version;
+	uint8_t		reciprocal;
+	uint16_t	port;
+	uint32_t	param;
+	uint32_t	tag;
+};
+
+struct fi_ibv_xrc_conn_info {
+	uint32_t		conn_tag;
+	uint32_t		is_reciprocal;
+	uint32_t		ini_qpn;
+	uint32_t		conn_data;
+	uint16_t		port;
+	struct rdma_conn_param	conn_param;
+};
 
 struct fi_ibv_connreq {
-	struct fid		handle;
-	struct rdma_cm_id	*id;
+	struct fid			handle;
+	struct rdma_cm_id		*id;
+
+	/* Support for XRC bidirectional connections, and
+	 * non-RDMA CM managed QP. */
+	struct fi_ibv_xrc_conn_info	xrc;
 };
 
 struct fi_ibv_cm_data_hdr {
 	uint8_t	size;
 	char	data[];
 };
+
+void fi_ibv_eq_set_xrc_conn_tag(struct fi_ibv_ep *ep);
+struct fi_ibv_ep *fi_ibv_eq_xrc_conn_tag2ep(struct fi_ibv_eq *eq,uint32_t tag);
+void fi_ibv_eq_clear_xrc_conn_tag(struct fi_ibv_ep *ep);
+
+void fi_ibv_set_xrc_cm_data(struct fi_ibv_xrc_cm_data *local, int reciprocal,
+			    uint32_t tag, uint16_t port, uint32_t param);
+int fi_ibv_verify_xrc_cm_data(struct fi_ibv_xrc_cm_data *remote,
+			      int private_data_len);
+int fi_ibv_connect_xrc(struct fi_ibv_ep *ep, struct sockaddr *addr,
+		       int reciprocal, void *param, size_t paramlen);
+int fi_ibv_accept_xrc(struct fi_ibv_ep *ep, int reciprocal,
+		      void *param, size_t paramlen);
+void fi_ibv_free_xrc_conn_setup(struct fi_ibv_ep *ep);
+int fi_ibv_process_xrc_connreq(struct fi_ibv_ep *ep,
+			       struct fi_ibv_connreq *connreq);
+int fi_ibv_process_xrc_recip_connreq(struct fi_ibv_eq *eq,
+				     struct fi_ibv_connreq *connreq,
+				     struct fi_eq_cm_entry *entry);
+void fi_ibv_add_pending_ini_conn(struct fi_ibv_ep *ep, int reciprocal,
+				 void *conn_param, size_t conn_paramlen);
+void fi_ibv_sched_ini_conn(struct fi_ibv_ini_shared_conn *ini_conn);
+struct fi_ibv_ini_shared_conn *fi_ibv_get_shared_ini_conn(struct fi_ibv_ep *ep);
+void fi_ibv_put_shared_ini_conn(struct fi_ibv_ep *ep);
+struct ibv_qp *fi_ibv_reserve_qpn(struct fi_ibv_ep *ep);
+void fi_ibv_release_qpn(struct ibv_qp *rsvd_qpn);
+
+struct fi_ibv_ep *fi_ibv_tag_to_ep(uint32_t tag);
+int fi_ibv_alloc_conn_tag(struct fi_ibv_ep *ep);
+void fi_ibv_free_conn_tag(uint32_t tag);
+int fi_ibv_xrc_msg_ep_connreq(struct fi_ibv_eq *eq,
+			      struct fi_ibv_connreq *connreq,
+			      struct fi_eq_cm_entry *entry);
+
+void fi_ibv_save_priv_data(struct fi_ibv_ep *ep, const void *data, size_t len);
+void fi_ibv_msg_ep_get_qp_attr(struct fi_ibv_ep *ep,
+			       struct fi_ibv_domain **domain,
+			       struct ibv_qp_init_attr *attr);
+
+int fi_ibv_ep_create_ini_qp(struct fi_ibv_ep *ep, void *dst_addr,
+			    uint32_t *peer_tgt_qpn);
+void fi_ibv_ep_ini_conn_done(struct fi_ibv_ep *qp, uint32_t peer_srqn,
+			    uint32_t peer_tgt_qpn);
+void fi_ibv_ep_ini_conn_rejected(struct fi_ibv_ep *ep);
+int fi_ibv_ep_create_tgt_qp(struct fi_ibv_ep *ep, uint32_t tgt_qpn);
+void fi_ibv_ep_tgt_conn_done(struct fi_ibv_ep *qp);
+int fi_ibv_ep_destroy_xrc_qp(struct fi_ibv_ep *ep);
 
 int fi_ibv_sockaddr_len(struct sockaddr *addr);
 
@@ -490,7 +747,7 @@ int fi_ibv_query_atomic(struct fid_domain *domain_fid, enum fi_datatype datatype
 int fi_ibv_set_rnr_timer(struct ibv_qp *qp);
 void fi_ibv_cleanup_cq(struct fi_ibv_ep *cur_ep);
 int fi_ibv_find_max_inline(struct ibv_pd *pd, struct ibv_context *context,
-                           enum ibv_qp_type qp_type);
+			   enum ibv_qp_type qp_type);
 
 struct fi_ibv_dgram_av {
 	struct util_av util_av;

--- a/prov/verbs/src/verbs_cm.c
+++ b/prov/verbs/src/verbs_cm.c
@@ -218,6 +218,48 @@ fi_ibv_msg_ep_accept(struct fid_ep *ep, const void *param, size_t paramlen)
 	return 0;
 }
 
+static void *fi_ibv_msg_alloc_xrc_params(const void *param, size_t *paramlen)
+{
+	struct fi_ibv_xrc_cm_data *cm_data;
+	size_t cm_datalen = sizeof(*cm_data) + *paramlen;
+
+	if (cm_datalen > FI_IBV_CM_DATA_SIZE) {
+		VERBS_WARN(FI_LOG_EP_CTRL, "XRC CM data overflow %"PRIu64"\n",
+			   cm_datalen);
+		errno = FI_EINVAL;
+		return NULL;
+	}
+
+	cm_data = malloc(cm_datalen);
+	if (!cm_data) {
+		errno = FI_ENOMEM;
+		return NULL;
+	}
+	if (paramlen)
+		memcpy((cm_data + 1), param, *paramlen);
+	*paramlen = cm_datalen;
+	return cm_data;
+}
+
+static int
+fi_ibv_msg_xrc_ep_reject(struct fi_ibv_connreq *connreq,
+			 const void *param, size_t paramlen)
+{
+	struct fi_ibv_xrc_cm_data *cm_data;
+	int ret;
+
+	cm_data = fi_ibv_msg_alloc_xrc_params(param, &paramlen);
+	if (!cm_data)
+		return -errno;
+
+	fi_ibv_set_xrc_cm_data(cm_data, connreq->xrc.is_reciprocal,
+			       connreq->xrc.conn_tag, connreq->xrc.port, 0);
+	ret = rdma_reject(connreq->id, cm_data,
+			  (uint8_t) paramlen) ? -errno : 0;
+	free(cm_data);
+	return ret;
+}
+
 static int
 fi_ibv_msg_ep_reject(struct fid_pep *pep, fid_t handle,
 		     const void *param, size_t paramlen)
@@ -233,8 +275,13 @@ fi_ibv_msg_ep_reject(struct fid_pep *pep, fid_t handle,
 	cm_hdr = alloca(sizeof(*cm_hdr) + paramlen);
 	fi_ibv_msg_ep_prepare_cm_data(param, paramlen, cm_hdr);
 
-	ret = rdma_reject(connreq->id, cm_hdr,
-			  (uint8_t)(sizeof(*cm_hdr) + paramlen)) ? -errno : 0;
+	if (fi_ibv_using_xrc())
+		ret = fi_ibv_msg_xrc_ep_reject(connreq, cm_hdr,
+				(uint8_t)(sizeof(*cm_hdr) + paramlen));
+
+	else
+		ret = rdma_reject(connreq->id, cm_hdr,
+			(uint8_t)(sizeof(*cm_hdr) + paramlen)) ? -errno : 0;
 	free(connreq);
 	return ret;
 }
@@ -243,7 +290,9 @@ static int fi_ibv_msg_ep_shutdown(struct fid_ep *ep, uint64_t flags)
 {
 	struct fi_ibv_ep *_ep =
 		container_of(ep, struct fi_ibv_ep, util_ep.ep_fid);
-	return rdma_disconnect(_ep->id) ? -errno : 0;
+	if (_ep->id)
+		return rdma_disconnect(_ep->id) ? -errno : 0;
+	return 0;
 }
 
 struct fi_ops_cm fi_ibv_msg_ep_cm_ops = {
@@ -254,6 +303,107 @@ struct fi_ops_cm fi_ibv_msg_ep_cm_ops = {
 	.connect = fi_ibv_msg_ep_connect,
 	.listen = fi_no_listen,
 	.accept = fi_ibv_msg_ep_accept,
+	.reject = fi_no_reject,
+	.shutdown = fi_ibv_msg_ep_shutdown,
+	.join = fi_no_join,
+};
+
+#ifdef INCLUDE_VERBS_XRC
+
+static int
+fi_ibv_msg_xrc_ep_connect(struct fid_ep *ep, const void *addr,
+		   const void *param, size_t paramlen)
+{
+	struct sockaddr *dst_addr;
+	void *adjusted_param;
+	struct fi_ibv_ep *_ep = container_of(ep, struct fi_ibv_ep,
+					     util_ep.ep_fid);
+	int ret;
+	struct fi_ibv_cm_data_hdr *cm_hdr;
+
+	if (!_ep->srqn) {
+		ret = ep->fid.ops->control(&ep->fid, FI_ENABLE, NULL);
+		if (ret)
+			return ret;
+	}
+
+	if (OFI_UNLIKELY(paramlen > VERBS_CM_DATA_SIZE -
+			 sizeof(struct fi_ibv_xrc_cm_data)))
+		return -FI_EINVAL;
+
+	cm_hdr = alloca(sizeof(*cm_hdr) + paramlen);
+	fi_ibv_msg_ep_prepare_cm_data(param, paramlen, cm_hdr);
+	paramlen += sizeof(*cm_hdr);
+	adjusted_param = fi_ibv_msg_alloc_xrc_params(cm_hdr, &paramlen);
+	if (!adjusted_param)
+		return -errno;
+
+	dst_addr = rdma_get_peer_addr(_ep->id);
+	ret = fi_ibv_connect_xrc(_ep, dst_addr, 0, adjusted_param, paramlen);
+	free(adjusted_param);
+	return ret;
+}
+
+static int
+fi_ibv_msg_xrc_ep_accept(struct fid_ep *ep, const void *param, size_t paramlen)
+{
+	void *adjusted_param;
+	struct fi_ibv_ep *_ep =
+		container_of(ep, struct fi_ibv_ep, util_ep.ep_fid);
+	int ret;
+	struct fi_ibv_cm_data_hdr *cm_hdr;
+
+	if (!_ep->srqn) {
+		ret = ep->fid.ops->control(&ep->fid, FI_ENABLE, NULL);
+		if (ret)
+			return ret;
+	}
+
+	if (OFI_UNLIKELY(paramlen > VERBS_CM_DATA_SIZE -
+			 sizeof(struct fi_ibv_xrc_cm_data)))
+		return -FI_EINVAL;
+
+	cm_hdr = alloca(sizeof(*cm_hdr) + paramlen);
+	fi_ibv_msg_ep_prepare_cm_data(param, paramlen, cm_hdr);
+	paramlen += sizeof(*cm_hdr);
+	adjusted_param = fi_ibv_msg_alloc_xrc_params(cm_hdr, &paramlen);
+	if (!adjusted_param)
+		return -errno;
+
+	ret = fi_ibv_accept_xrc(_ep, 0, adjusted_param, paramlen);
+	free(adjusted_param);
+	return ret;
+}
+
+#else /* INCLUDE_VERBS_XRC */
+
+static int
+fi_ibv_msg_xrc_ep_connect(struct fid_ep *ep, const void *addr,
+		   const void *param, size_t paramlen)
+{
+	/* Should not be callable if XRC is not enabled */
+	assert(0);
+	return -FI_ENOSYS;
+}
+
+static int
+fi_ibv_msg_xrc_ep_accept(struct fid_ep *ep, const void *param, size_t paramlen)
+{
+	/* Should not be callable if XRC is not enabled */
+	assert(0);
+	return -FI_ENOSYS;
+}
+
+#endif /* INCLUDE_VERBS_XRC */
+
+struct fi_ops_cm fi_ibv_msg_xrc_ep_cm_ops = {
+	.size = sizeof(struct fi_ops_cm),
+	.setname = fi_ibv_msg_ep_setname,
+	.getname = fi_ibv_msg_ep_getname,
+	.getpeer = fi_ibv_msg_ep_getpeer,
+	.connect = fi_ibv_msg_xrc_ep_connect,
+	.listen = fi_no_listen,
+	.accept = fi_ibv_msg_xrc_ep_accept,
 	.reject = fi_no_reject,
 	.shutdown = fi_ibv_msg_ep_shutdown,
 	.join = fi_no_join,

--- a/prov/verbs/src/verbs_cm_xrc.c
+++ b/prov/verbs/src/verbs_cm_xrc.c
@@ -1,0 +1,449 @@
+/*
+ * Copyright (c) 2018 Cray Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "config.h"
+#include "fi_verbs.h"
+
+#ifdef INCLUDE_VERBS_XRC
+void fi_ibv_save_priv_data(struct fi_ibv_ep *ep, const void *data, size_t len)
+{
+	ep->conn_setup->event_len = MIN(sizeof(ep->conn_setup->event_data),
+					len);
+	memcpy(ep->conn_setup->event_data, data, ep->conn_setup->event_len);
+}
+
+void fi_ibv_set_xrc_cm_data(struct fi_ibv_xrc_cm_data *local, int reciprocal,
+			    uint32_t tag, uint16_t port, uint32_t param)
+{
+	local->version = FI_IBV_XRC_VERSION;
+	local->reciprocal = reciprocal ? 1 : 0;
+	local->port = htons(port);
+	local->tag = htonl(tag);
+	local->param = htonl(param);
+}
+
+int fi_ibv_verify_xrc_cm_data(struct fi_ibv_xrc_cm_data *remote,
+			      int private_data_len)
+{
+	if (sizeof(*remote) > private_data_len) {
+		VERBS_WARN(FI_LOG_EP_CTRL,
+			   "XRC MSG EP CM data length mismatch\n");
+		return -FI_EINVAL;
+	}
+
+	if (remote->version != FI_IBV_XRC_VERSION) {
+		VERBS_WARN(FI_LOG_EP_CTRL,
+			   "XRC MSG EP connection protocol mismatch "
+			   "(local %"PRIu8", remote %"PRIu8")\n",
+			   FI_IBV_XRC_VERSION, remote->version);
+		return -FI_EINVAL;
+	}
+	return FI_SUCCESS;
+}
+
+#if ENABLE_DEBUG
+void fi_ibv_log_ep_conn(struct fi_ibv_ep *ep, char *desc)
+{
+	struct sockaddr *src_addr, *dst_addr;
+
+	VERBS_DBG(FI_LOG_FABRIC, "EP %p, %s\n", ep, desc);
+	VERBS_DBG(FI_LOG_FABRIC,
+		  "EP %p, CM ID %p, TGT CM ID %p, SRQN %d Peer SRQN %d\n",
+		  ep, ep->id, ep->tgt_id, ep->srqn, ep->peer_srqn);
+
+	assert(ep->id);
+
+	src_addr = rdma_get_local_addr(ep->id);
+	if (src_addr) {
+		VERBS_DBG(FI_LOG_FABRIC, "EP %p src_addr: %s:%d\n", ep,
+			inet_ntoa(((struct sockaddr_in *)src_addr)->sin_addr),
+			ntohs(((struct sockaddr_in *)src_addr)->sin_port));
+	}
+	dst_addr = rdma_get_peer_addr(ep->id);
+	if (dst_addr) {
+		VERBS_DBG(FI_LOG_FABRIC, "EP %p dst_addr: %s:%d\n", ep,
+			inet_ntoa(((struct sockaddr_in *)dst_addr)->sin_addr),
+			ntohs(((struct sockaddr_in *)dst_addr)->sin_port));
+	}
+
+	if (ep->ibv_qp) {
+		VERBS_DBG(FI_LOG_FABRIC, "EP %p, INI QP Num %d\n",
+			  ep, ep->ibv_qp->qp_num);
+		VERBS_DBG(FI_LOG_FABRIC, "EP %p, Remote TGT QP Num %d\n", ep,
+			  ep->ini_conn->tgt_qpn);
+	}
+	if (ep->tgt_ibv_qp)
+		VERBS_DBG(FI_LOG_FABRIC, "EP %p, TGT QP Num %d\n",
+			  ep, ep->tgt_ibv_qp->qp_num);
+	if (ep->conn_setup && ep->conn_setup->rsvd_ini_qpn)
+		VERBS_DBG(FI_LOG_FABRIC, "EP %p, Reserved INI QPN %d\n",
+			  ep, ep->conn_setup->rsvd_ini_qpn->qp_num);
+	if (ep->conn_setup && ep->conn_setup->rsvd_tgt_qpn)
+		VERBS_DBG(FI_LOG_FABRIC, "EP %p, Reserved TGT QPN %d\n",
+			  ep, ep->conn_setup->rsvd_tgt_qpn->qp_num);
+}
+#endif
+
+void fi_ibv_free_xrc_conn_setup(struct fi_ibv_ep *ep)
+{
+	assert(ep->conn_setup);
+
+	if (ep->conn_setup->rsvd_ini_qpn)
+		fi_ibv_release_qpn(ep->conn_setup->rsvd_ini_qpn);
+	if (ep->conn_setup->rsvd_tgt_qpn)
+		fi_ibv_release_qpn(ep->conn_setup->rsvd_tgt_qpn);
+
+	free(ep->conn_setup);
+	ep->conn_setup = NULL;
+
+	/*Free RDMA CM IDs releasing their associated resources, RDMA CM
+	 * is used for connection setup only with XRC */
+	if (ep->id) {
+		rdma_destroy_id(ep->id);
+		ep->id = NULL;
+	}
+	if (ep->tgt_id) {
+		rdma_destroy_id(ep->tgt_id);
+		ep->tgt_id = NULL;
+	}
+}
+
+int fi_ibv_connect_xrc(struct fi_ibv_ep *ep, struct sockaddr *addr,
+		       int reciprocal, void *param, size_t paramlen)
+{
+	struct fi_ibv_domain *domain = fi_ibv_msg_ep_to_domain(ep);
+	struct sockaddr *src_addr, *dst_addr;
+	int ret;
+
+	assert(ep->id && !ep->ibv_qp && !ep->ini_conn);
+
+	src_addr = rdma_get_local_addr(ep->id);
+	if (src_addr) {
+		VERBS_DBG(FI_LOG_FABRIC, "XRC connect src_addr: %s:%d\n",
+			inet_ntoa(((struct sockaddr_in *)src_addr)->sin_addr),
+			ntohs(((struct sockaddr_in *)src_addr)->sin_port));
+	}
+	dst_addr = rdma_get_peer_addr(ep->id);
+	if (dst_addr) {
+		VERBS_DBG(FI_LOG_FABRIC, "XRC connect dst_addr: %s:%d\n",
+			  inet_ntoa(((struct sockaddr_in *)dst_addr)->sin_addr),
+			  ntohs(((struct sockaddr_in *)dst_addr)->sin_port));
+	}
+
+	if (!reciprocal) {
+		ep->conn_setup = calloc(1, sizeof(*ep->conn_setup));
+		if (!ep)
+			return -FI_ENOMEM;
+	}
+
+	fastlock_acquire(&domain->xrc.ini_mgmt_lock);
+	ep->ini_conn = fi_ibv_get_shared_ini_conn(ep);
+	if (!ep->ini_conn) {
+		ret = -errno;
+		VERBS_WARN(FI_LOG_FABRIC,
+			   "Get of shared XRC INI connection failed %d\n", ret);
+		fastlock_release(&domain->xrc.ini_mgmt_lock);
+		if (!reciprocal) {
+			free(ep->conn_setup);
+			ep->conn_setup = NULL;
+		}
+		return ret;
+	}
+	fi_ibv_add_pending_ini_conn(ep, reciprocal, param, paramlen);
+	fi_ibv_sched_ini_conn(ep->ini_conn);
+	fastlock_release(&domain->xrc.ini_mgmt_lock);
+
+	return FI_SUCCESS;
+}
+
+void fi_ibv_ep_ini_conn_done(struct fi_ibv_ep *ep, uint32_t peer_srqn,
+			     uint32_t tgt_qpn)
+{
+	struct fi_ibv_domain *domain = fi_ibv_msg_ep_to_domain(ep);
+
+	assert(ep->id && ep->ini_conn);
+
+	fastlock_acquire(&domain->xrc.ini_mgmt_lock);
+#if ENABLE_DEBUG
+	fi_ibv_log_ep_conn(ep, "INI Connection Done");
+#endif
+	assert(ep->ini_conn->state == FI_IBV_INI_QP_CONNECTING ||
+	       ep->ini_conn->state == FI_IBV_INI_QP_CONNECTED);
+
+	/* If this was a physical INI/TGT QP connection, remove the QP
+	 * from control of the RDMA CM. We don't want the shared INI QP
+	 * to be destroyed if this endpoint closes. */
+	if (ep->id->qp) {
+		ep->ini_conn->state = FI_IBV_INI_QP_CONNECTED;
+		ep->ini_conn->tgt_qpn = tgt_qpn;
+		ep->id->qp = NULL;
+		VERBS_DBG(FI_LOG_EP_CTRL,
+			  "Set INI Conn QP %d remote TGT QP %d\n",
+			  ep->ini_conn->ini_qp->qp_num,
+			  ep->ini_conn->tgt_qpn);
+	}
+
+	fi_ibv_sched_ini_conn(ep->ini_conn);
+	fastlock_release(&domain->xrc.ini_mgmt_lock);
+}
+
+void fi_ibv_ep_ini_conn_rejected(struct fi_ibv_ep *ep)
+{
+	struct fi_ibv_domain *domain = fi_ibv_msg_ep_to_domain(ep);
+
+	assert(ep->id && ep->ini_conn);
+
+	fastlock_acquire(&domain->xrc.ini_mgmt_lock);
+#if ENABLE_DEBUG
+	fi_ibv_log_ep_conn(ep, "INI Connection Rejected");
+#endif
+	fi_ibv_put_shared_ini_conn(ep);
+	fastlock_release(&domain->xrc.ini_mgmt_lock);
+}
+
+void fi_ibv_ep_tgt_conn_done(struct fi_ibv_ep *ep)
+{
+#if ENABLE_DEBUG
+	fi_ibv_log_ep_conn(ep, "TGT Connection Done\n");
+#endif
+	if (ep->tgt_id->qp) {
+		assert(ep->tgt_ibv_qp == ep->tgt_id->qp);
+		ep->tgt_id->qp = NULL;
+	}
+}
+
+int fi_ibv_accept_xrc(struct fi_ibv_ep *ep, int reciprocal,
+		      void *param, size_t paramlen)
+{
+	struct sockaddr *src_addr, *dst_addr;
+	struct fi_ibv_connreq *connreq;
+	struct rdma_conn_param conn_param = { 0 };
+	struct fi_ibv_xrc_cm_data *cm_data = param;
+	int ret;
+
+	src_addr = rdma_get_local_addr(ep->tgt_id);
+	if (src_addr) {
+		VERBS_INFO(FI_LOG_CORE, "src_addr: %s:%d\n",
+			inet_ntoa(((struct sockaddr_in *)src_addr)->sin_addr),
+			ntohs(((struct sockaddr_in *)src_addr)->sin_port));
+	}
+	dst_addr = rdma_get_peer_addr(ep->tgt_id);
+	if (dst_addr) {
+		VERBS_INFO(FI_LOG_CORE, "dst_addr: %s:%d\n",
+			inet_ntoa(((struct sockaddr_in *)dst_addr)->sin_addr),
+			ntohs(((struct sockaddr_in *)dst_addr)->sin_port));
+	}
+
+	connreq = container_of(ep->info->handle, struct fi_ibv_connreq,
+			       handle);
+	ret = fi_ibv_ep_create_tgt_qp(ep, connreq->xrc.conn_data);
+	if (ret)
+		return ret;
+
+	fi_ibv_set_xrc_cm_data(cm_data, connreq->xrc.is_reciprocal,
+			       connreq->xrc.conn_tag, connreq->xrc.port,
+			       ep->srqn);
+	conn_param.private_data = cm_data;
+	conn_param.private_data_len = paramlen;
+	conn_param.responder_resources = RDMA_MAX_RESP_RES;
+	conn_param.initiator_depth = RDMA_MAX_INIT_DEPTH;
+	conn_param.flow_control = 1;
+	conn_param.rnr_retry_count = 7;
+	if (ep->srq_ep)
+		conn_param.srq = 1;
+
+	/* Shared INI/TGT QP connection use a temporarily reserved QP number
+	 * avoid the appearance of being a stale/duplicate IB CM message */
+	if (!ep->tgt_id->qp)
+		conn_param.qp_num = ep->conn_setup->rsvd_tgt_qpn->qp_num;
+
+	if (connreq->xrc.is_reciprocal)
+		fi_ibv_eq_clear_xrc_conn_tag(ep);
+	else
+		ep->conn_setup->tag = connreq->xrc.conn_tag;
+
+	assert(ep->conn_state == FI_IBV_XRC_UNCONNECTED ||
+	       ep->conn_state == FI_IBV_XRC_ORIG_CONNECTED);
+	ep->conn_state++;
+
+	ret = rdma_accept(ep->tgt_id, &conn_param);
+	if (ret) {
+		ret = -errno;
+		VERBS_INFO_ERRNO(FI_LOG_EP_CTRL,
+				 "XRC TGT, ibv_open_qp", errno);
+		ep->conn_state--;
+	}
+	free(connreq);
+	return ret;
+}
+
+int fi_ibv_process_xrc_connreq(struct fi_ibv_ep *ep,
+			       struct fi_ibv_connreq *connreq)
+{
+	int ret;
+
+	assert(ep->info->src_addr);
+	assert(ep->info->dest_addr);
+
+	ep->conn_setup = calloc(1, sizeof(*ep->conn_setup));
+	if (!ep->conn_setup)
+		return -FI_ENOMEM;
+
+	/* This endpoint was created on the passive side of a connection
+	 * request. The connection information will be for the target QP. */
+	ep->tgt_info = fi_dupinfo(ep->info);
+	if (!ep->tgt_info) {
+		ret = -FI_ENOMEM;
+		goto dup_err;
+	}
+
+	/* The reciprocal connection request will go back to the passive
+	 * port indicated by the active side */
+	if (((struct sockaddr *)ep->info->src_addr)->sa_family == AF_INET) {
+		((struct sockaddr_in *)(ep->info->src_addr))->sin_port = 0;
+		((struct sockaddr_in *)(ep->info->dest_addr))->sin_port =
+						htons(connreq->xrc.port);
+	} else if (((struct sockaddr *)ep->info->src_addr)->sa_family ==
+								AF_INET6) {
+		((struct sockaddr_in6 *)(ep->info->src_addr))->sin6_port = 0;
+		((struct sockaddr_in6 *)(ep->info->dest_addr))->sin6_port =
+						htons(connreq->xrc.port);
+	} else
+		assert(0);
+
+	ret = fi_ibv_create_ep(NULL, NULL, 0, ep->info, NULL, &ep->id);
+	if (ret) {
+		VERBS_WARN(FI_LOG_EP_CTRL,
+			   "Creation of INI cm_id failed %d\n", ret);
+		goto create_err;
+	}
+	ep->tgt_id = connreq->id;
+	ep->tgt_id->context = &ep->util_ep.ep_fid.fid;
+
+	return FI_SUCCESS;
+
+create_err:
+	fi_freeinfo(ep->tgt_info);
+	ep->tgt_info = NULL;
+dup_err:
+	free(ep->conn_setup);
+	return ret;
+}
+
+int fi_ibv_process_xrc_recip_connreq(struct fi_ibv_eq *eq,
+				     struct fi_ibv_connreq *connreq,
+				     struct fi_eq_cm_entry *entry)
+{
+	struct fi_ibv_ep *ep;
+	struct fi_ibv_xrc_cm_data xrc_cm_data;
+	size_t xrc_cm_datalen;
+	int ret;
+
+	ep = fi_ibv_eq_xrc_conn_tag2ep(eq, connreq->xrc.conn_tag);
+	if (!ep)
+		return -FI_EINVAL;
+
+	ep->tgt_id = connreq->id;
+	ep->tgt_info = fi_dupinfo(entry->info);
+	if (!ep->tgt_info) {
+		VERBS_WARN(FI_LOG_FABRIC, "fi_dupinfo for TGT failed\n");
+		return -FI_EINVAL;
+	}
+	ep->tgt_id->context = &ep->util_ep.ep_fid.fid;
+	ep->info->handle = entry->info->handle;
+
+	ret = rdma_migrate_id(ep->tgt_id, ep->eq->channel);
+	if (ret) {
+		ret = -errno;
+		VERBS_WARN(FI_LOG_FABRIC, "Could not migrate XRC tgt_id %d\n",
+			   ret);
+		goto err;
+	}
+
+	xrc_cm_datalen = sizeof(xrc_cm_data);
+	ret = fi_ibv_accept_xrc(ep, FI_IBV_RECIP_CONN, &xrc_cm_data,
+				xrc_cm_datalen);
+	if (ret) {
+		VERBS_WARN(FI_LOG_FABRIC,
+			   "Reciprocal XRC Accept failed %d\n", ret);
+		goto err;
+	}
+	return -FI_EAGAIN;
+
+err:
+	fi_freeinfo(ep->tgt_info);
+	ep->tgt_info = NULL;
+	return -FI_EAGAIN;
+}
+
+#else /* INCLUDE_VERBS_XRC */
+
+void fi_ibv_set_xrc_cm_data(struct fi_ibv_xrc_cm_data *local, int reciprocal,
+			    uint32_t tag, uint16_t port, uint32_t param)
+{
+	/* Code error if this function is called with XRC disabled */
+	assert(0);
+}
+
+int fi_ibv_verify_xrc_cm_data(struct fi_ibv_xrc_cm_data *remote,
+			      int private_data_len)
+{
+	/* Code error if this function is called with XRC disabled */
+	assert(0);
+	return -FI_ENOSYS;
+}
+
+int fi_ibv_connect_xrc(struct fi_ibv_ep *ep, struct sockaddr *addr,
+		       int reciprocal, void *param, size_t paramlen)
+{
+	/* Code error if this function is called with XRC disabled */
+	assert(0);
+	return -FI_ENOSYS;
+}
+
+int fi_ibv_accept_xrc(struct fi_ibv_ep *ep, int reciprocal,
+		      void *param, size_t paramlen)
+{
+	/* Code error if this function is called with XRC disabled */
+	assert(0);
+	return -FI_ENOSYS;
+}
+
+int fi_ibv_process_xrc_connreq(struct fi_ibv_ep *ep,
+			       struct fi_ibv_connreq *connreq)
+{
+	/* Code error if this function is called with XRC disabled */
+	assert(0);
+	return -FI_ENOSYS;
+}
+
+#endif /* INCLUDE_VERBS_XRC */

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -258,6 +258,11 @@ static int fi_ibv_domain_close(fid_t fid)
 			ofi_ns_stop_server(&fab->name_server);
 		break;
 	case FI_EP_MSG:
+		if (domain->use_xrc) {
+			ret = fi_ibv_domain_xrc_cleanup(domain);
+			if (ret)
+				return ret;
+		}
 		break;
 	default:
 		/* Never should go here */
@@ -378,6 +383,24 @@ static void fi_ibv_domain_process_exp(struct fi_ibv_domain *domain)
 	domain->use_odp = fi_ibv_gl_data.use_odp;
 }
 
+static int fi_ibv_domain_check_xrc(struct fi_ibv_domain *domain)
+{
+	struct ibv_device_attr attr;
+	int ret;
+
+	domain->use_xrc = 0;
+
+	if (domain->ep_type != FI_EP_MSG || !fi_ibv_using_xrc())
+		return 0;
+
+	ret = ibv_query_device(domain->verbs, &attr);
+	if (ret || !(attr.device_cap_flags & IBV_DEVICE_XRC)) {
+		VERBS_INFO(FI_LOG_DOMAIN, "XRC is not supported");
+		return -FI_EINVAL;
+	}
+	return fi_ibv_domain_xrc_init(domain);
+}
+
 static int
 fi_ibv_domain(struct fid_fabric *fabric, struct fi_info *info,
 	      struct fid_domain **domain, void *context)
@@ -470,6 +493,9 @@ fi_ibv_domain(struct fid_fabric *fabric, struct fi_info *info,
 		_domain->util_domain.domain_fid.ops = &fi_ibv_dgram_domain_ops;
 		break;
 	case FI_EP_MSG:
+		ret = fi_ibv_domain_check_xrc(_domain);
+		if (ret)
+			goto err5;
 		_domain->util_domain.domain_fid.ops = &fi_ibv_msg_domain_ops;
 		break;
 	default:
@@ -481,6 +507,9 @@ fi_ibv_domain(struct fid_fabric *fabric, struct fi_info *info,
 
 	*domain = &_domain->util_domain.domain_fid;
 	return FI_SUCCESS;
+err5:
+	if (fi_ibv_gl_data.mr_cache_enable)
+		ofi_mr_cache_cleanup(&_domain->cache);
 err4:
 	if (fi_ibv_gl_data.mr_cache_enable)
 		ofi_monitor_cleanup(&_domain->monitor);

--- a/prov/verbs/src/verbs_domain_xrc.c
+++ b/prov/verbs/src/verbs_domain_xrc.c
@@ -1,0 +1,576 @@
+/*
+ * Copyright (c) 2018 Cray Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#include "config.h"
+#include "fi_verbs.h"
+
+#ifdef INCLUDE_VERBS_XRC
+
+/* Domain XRC INI QP RBTree key */
+struct fi_ibv_ini_conn_key {
+	struct sockaddr		*addr;
+	struct fi_ibv_cq	*tx_cq;
+};
+
+struct fi_ibv_domain *fi_ibv_msg_ep_to_domain(struct fi_ibv_ep *ep)
+{
+	struct fi_ibv_domain *domain = NULL;
+
+	if (ep->util_ep.tx_cq)
+		domain = container_of(ep->util_ep.tx_cq->domain,
+				      struct fi_ibv_domain, util_domain);
+	else if (ep->util_ep.rx_cq)
+		domain = container_of(ep->util_ep.rx_cq->domain,
+				      struct fi_ibv_domain, util_domain);
+
+	/* Only valid to call this function after CQ(s) are bound */
+	assert(domain);
+	return domain;
+}
+
+/*
+ * This routine is a work around that creates a QP for the only purpose of
+ * reserving the QP number. The QP is not transitioned out of the RESET state.
+ */
+struct ibv_qp *fi_ibv_reserve_qpn(struct fi_ibv_ep *ep)
+{
+	struct fi_ibv_domain *domain = fi_ibv_msg_ep_to_domain(ep);
+	struct fi_ibv_cq *cq = container_of(ep->util_ep.tx_cq,
+					    struct fi_ibv_cq, util_cq);
+	struct ibv_qp *qp;
+	struct ibv_qp_init_attr attr = { 0 };
+	int ret;
+
+	/* Limit library allocated resources and do not INIT QP */
+	attr.cap.max_send_wr = 1;
+	attr.cap.max_send_sge = 1;
+	attr.cap.max_recv_wr = 0;
+	attr.cap.max_recv_sge = 0;
+	attr.cap.max_inline_data = 0;
+	attr.send_cq = cq->cq;
+	attr.recv_cq = cq->cq;
+	attr.qp_type = IBV_QPT_RC;
+
+	qp = ibv_create_qp(domain->pd, &attr);
+	if (!qp) {
+		ret = -errno;
+		VERBS_INFO_ERRNO(FI_LOG_EP_CTRL,
+				 "Reservation QP create failed", ret);
+		return NULL;
+	}
+	return qp;
+}
+
+void fi_ibv_release_qpn(struct ibv_qp *rsvd_qp)
+{
+	ibv_destroy_qp(rsvd_qp);
+}
+
+static int fi_ibv_create_ini_qp(struct fi_ibv_ep *ep)
+{
+	struct ibv_qp_init_attr_ex attr_ex;
+	struct fi_ibv_domain *domain = fi_ibv_msg_ep_to_domain(ep);
+	int ret;
+
+	fi_ibv_msg_ep_get_qp_attr(ep, NULL,
+			(struct ibv_qp_init_attr *)&attr_ex);
+	attr_ex.qp_type = IBV_QPT_XRC_SEND;
+	attr_ex.comp_mask = IBV_QP_INIT_ATTR_PD;
+	attr_ex.pd = domain->pd;
+	attr_ex.qp_context = domain;
+
+	ret = rdma_create_qp_ex(ep->id, &attr_ex);
+	if (ret) {
+		ret = -errno;
+		VERBS_INFO_ERRNO(FI_LOG_EP_CTRL,
+				 "XRC INI QP, rdma_create_qp_ex()", -ret);
+		return ret;
+	}
+	return FI_SUCCESS;
+}
+
+static inline void fi_ibv_set_ini_conn_key(struct fi_ibv_ep *ep,
+					   struct fi_ibv_ini_conn_key *key)
+{
+	key->addr = ep->info->dest_addr;
+	key->tx_cq = container_of(ep->util_ep.tx_cq, struct fi_ibv_cq, util_cq);
+}
+
+/* Caller must hold domain:xrc:ini_mgmt_lock */
+struct fi_ibv_ini_shared_conn *fi_ibv_get_shared_ini_conn(struct fi_ibv_ep *ep)
+{
+	struct fi_ibv_domain *domain = fi_ibv_msg_ep_to_domain(ep);
+	struct fi_ibv_ini_conn_key key;
+	struct fi_ibv_ini_shared_conn *ini_conn;
+	struct ofi_rbnode *node;
+	int ret;
+
+	assert(ep->id);
+
+	fi_ibv_set_ini_conn_key(ep, &key);
+	node = ofi_rbmap_find(domain->xrc.ini_conn_rbmap, &key);
+	if (node) {
+		ini_conn = node->data;
+		ofi_atomic_inc32(&ini_conn->ref_cnt);
+		return ini_conn;
+	}
+
+	ini_conn = calloc(1, sizeof(*ini_conn));
+	if (!ini_conn) {
+		errno = FI_ENOMEM;
+		return NULL;
+	}
+
+	ini_conn->tgt_qpn = FI_IBV_NO_INI_TGT_QPNUM;
+	ini_conn->peer_addr = mem_dup(key.addr, ofi_sizeofaddr(key.addr));
+	if (!ini_conn->peer_addr) {
+		free(ini_conn);
+		errno = FI_ENOMEM;
+		return NULL;
+	}
+	ini_conn->tx_cq = container_of(ep->util_ep.tx_cq,
+				       struct fi_ibv_cq, util_cq);
+	dlist_init(&ini_conn->pending_list);
+	dlist_init(&ini_conn->active_list);
+	ofi_atomic_initialize32(&ini_conn->ref_cnt, 1);
+
+	ret = ofi_rbmap_insert(domain->xrc.ini_conn_rbmap,
+			       (void *) &key, (void *) ini_conn);
+	assert(ret != -FI_EALREADY);
+	if (ret) {
+		VERBS_WARN(FI_LOG_FABRIC, "INI QP RBTree insert failed %d\n",
+			   ret);
+		errno = -ret;
+		goto insert_err;
+	}
+	return ini_conn;
+
+insert_err:
+	free(ini_conn->peer_addr);
+	free(ini_conn);
+	return NULL;
+}
+
+/* Caller must hold domain:xrc:ini_mgmt_lock */
+void fi_ibv_put_shared_ini_conn(struct fi_ibv_ep *ep)
+{
+	struct fi_ibv_domain *domain = fi_ibv_msg_ep_to_domain(ep);
+	struct fi_ibv_ini_shared_conn *ini_conn = ep->ini_conn;
+	struct fi_ibv_ini_conn_key key;
+	struct ofi_rbnode *node;
+
+	if (!ini_conn)
+		return;
+
+	/* remove from pending or active connection list */
+	dlist_remove(&ep->ini_conn_entry);
+	ep->conn_state = FI_IBV_XRC_UNCONNECTED;
+	ep->ini_conn = NULL;
+	ep->ibv_qp = NULL;
+
+	/* Tear down physical INI/TGT when no longer being used */
+	if (!ofi_atomic_dec32(&ini_conn->ref_cnt)) {
+		if (ibv_destroy_qp(ini_conn->ini_qp))
+			VERBS_WARN(FI_LOG_FABRIC, "destroy of QP error %d\n",
+				   errno);
+
+		fi_ibv_set_ini_conn_key(ep, &key);
+		node = ofi_rbmap_find(domain->xrc.ini_conn_rbmap, &key);
+		assert(node);
+		ofi_rbmap_delete(domain->xrc.ini_conn_rbmap, node);
+		free(ini_conn->peer_addr);
+		free(ini_conn);
+		return;
+	}
+
+	fi_ibv_sched_ini_conn(ini_conn);
+}
+
+/* Caller must hold domain:xrc:ini_mgmt_lock */
+void fi_ibv_add_pending_ini_conn(struct fi_ibv_ep *ep, int reciprocal,
+				 void *conn_param, size_t conn_paramlen)
+{
+	ep->conn_setup->pending_recip = reciprocal;
+	ep->conn_setup->pending_paramlen = MIN(conn_paramlen,
+				sizeof(ep->conn_setup->pending_param));
+	memcpy(ep->conn_setup->pending_param, conn_param,
+	       ep->conn_setup->pending_paramlen);
+	dlist_insert_tail(&ep->ini_conn_entry, &ep->ini_conn->pending_list);
+}
+
+static void fi_ibv_create_shutdown_event(struct fi_ibv_ep *ep)
+{
+	struct fi_eq_cm_entry entry = {
+		.fid = &ep->util_ep.ep_fid.fid,
+	};
+
+	fi_ibv_eq_write_event(ep->eq, FI_SHUTDOWN, &entry, sizeof(entry));
+}
+
+static int fi_ibv_process_ini_conn(struct fi_ibv_ep *ep,int reciprocal,
+				   void *param, size_t paramlen);
+
+/* Caller must hold domain:xrc:ini_mgmt_lock */
+void fi_ibv_sched_ini_conn(struct fi_ibv_ini_shared_conn *ini_conn)
+{
+	struct fi_ibv_ep *ep;
+	enum fi_ibv_ini_qp_state last_state;
+	int ret;
+
+sched_next:
+	if (dlist_empty(&ini_conn->pending_list) ||
+			ini_conn->state == FI_IBV_INI_QP_CONNECTING)
+		return;
+
+	dlist_pop_front(&ini_conn->pending_list, struct fi_ibv_ep,
+			ep, ini_conn_entry);
+
+	last_state = ep->ini_conn->state;
+	if (last_state == FI_IBV_INI_QP_UNCONNECTED) {
+		ret = fi_ibv_create_ini_qp(ep);
+		if (ret) {
+			VERBS_WARN(FI_LOG_FABRIC,
+				   "Failed to create physical INI QP %d\n",
+				   ret);
+			abort();
+		}
+		ep->ini_conn->ini_qp = ep->id->qp;
+		ep->ini_conn->state = FI_IBV_INI_QP_CONNECTING;
+	} else {
+		if (!ep->id->qp) {
+			ep->conn_setup->rsvd_ini_qpn = fi_ibv_reserve_qpn(ep);
+			if (!ep->conn_setup->rsvd_ini_qpn) {
+				VERBS_WARN(FI_LOG_FABRIC,
+					  "rsvd_ini_qpn create err %d\n",
+					  errno);
+				abort();
+			}
+		}
+	}
+
+	assert(ep->ini_conn->ini_qp);
+
+	ep->ibv_qp = ep->ini_conn->ini_qp;
+	dlist_insert_tail(&ep->ini_conn_entry,
+			  &ep->ini_conn->active_list);
+
+	ret = fi_ibv_process_ini_conn(ep, ep->conn_setup->pending_recip,
+				      ep->conn_setup->pending_param,
+				      ep->conn_setup->pending_paramlen);
+	if (ret) {
+		ep->ini_conn->state = last_state;
+		fi_ibv_put_shared_ini_conn(ep);
+
+		/* We need to let the application know that the connect request
+		 * has failed. */
+		fi_ibv_create_shutdown_event(ep);
+	}
+
+	/* Continue to schedule shared connections if the physical connection
+	 * has completed and there are connection requests pending. We could
+	 * implement a throttle here if it is determined that it is better to
+	 * limit the number of outstanding connections. */
+	goto sched_next;
+
+	return;
+}
+
+/* Caller must hold domain:xrc:ini_mgmt_lock */
+int fi_ibv_process_ini_conn(struct fi_ibv_ep *ep,int reciprocal,
+			    void *param, size_t paramlen)
+{
+	struct fi_ibv_xrc_cm_data *cm_data = param;
+	struct rdma_conn_param conn_param = { 0 };
+	int ret;
+
+	assert(ep->ibv_qp);
+
+	if (!reciprocal)
+		fi_ibv_eq_set_xrc_conn_tag(ep);
+
+	fi_ibv_set_xrc_cm_data(cm_data, reciprocal, ep->conn_setup->tag,
+			       ep->eq->pep_port, ep->ini_conn->tgt_qpn);
+	conn_param.private_data = cm_data;
+	conn_param.private_data_len = paramlen;
+	conn_param.responder_resources = RDMA_MAX_RESP_RES;
+	conn_param.initiator_depth = RDMA_MAX_INIT_DEPTH;
+	conn_param.flow_control = 1;
+	conn_param.retry_count = 15;
+	conn_param.rnr_retry_count = 7;
+	conn_param.srq = 1;
+
+	/* Shared connections use reserved temporary QP numbers to
+	 * avoid the appearance of stale/duplicate CM messages */
+	if (!ep->id->qp)
+		conn_param.qp_num = ep->conn_setup->rsvd_ini_qpn->qp_num;
+
+	assert(ep->conn_state == FI_IBV_XRC_UNCONNECTED ||
+	       ep->conn_state == FI_IBV_XRC_ORIG_CONNECTED);
+	ep->conn_state++;
+
+	ret = rdma_connect(ep->id, &conn_param) ? -errno : 0;
+	if (ret) {
+		ret = -errno;
+		VERBS_INFO_ERRNO(FI_LOG_FABRIC, "rdma_connect", errno);
+		ep->conn_state--;
+	}
+	return ret;
+}
+
+int fi_ibv_ep_create_tgt_qp(struct fi_ibv_ep *ep, uint32_t tgt_qpn)
+{
+	struct ibv_qp_open_attr open_attr;
+	struct ibv_qp_init_attr_ex attr_ex;
+	struct fi_ibv_domain *domain = fi_ibv_msg_ep_to_domain(ep);
+	struct ibv_qp *rsvd_qpn;
+
+	assert(ep->tgt_id && !ep->tgt_id->qp);
+
+	/* If a target QP number was specified then open that existing
+	 * QP for sharing. */
+	if (tgt_qpn) {
+		rsvd_qpn = fi_ibv_reserve_qpn(ep);
+		if (!rsvd_qpn) {
+			VERBS_WARN(FI_LOG_FABRIC,
+				   "Create of XRC reserved QPN failed %d\n",
+				   errno);
+			return -errno;
+		}
+
+		memset(&open_attr, 0, sizeof(open_attr));
+		open_attr.qp_num = tgt_qpn;
+		open_attr.comp_mask = IBV_QP_OPEN_ATTR_NUM |
+			IBV_QP_OPEN_ATTR_XRCD | IBV_QP_OPEN_ATTR_TYPE |
+			IBV_QP_OPEN_ATTR_CONTEXT;
+		open_attr.xrcd = domain->xrc.xrcd;
+		open_attr.qp_type = IBV_QPT_XRC_RECV;
+		open_attr.qp_context = ep;
+
+		ep->tgt_ibv_qp = ibv_open_qp(domain->verbs, &open_attr);
+		if (!ep->tgt_ibv_qp) {
+			VERBS_INFO_ERRNO(FI_LOG_EP_CTRL,
+				   "XRC TGT QP, ibv_open_qp()", errno);
+			fi_ibv_release_qpn(rsvd_qpn);
+			return -errno;
+		}
+		ep->conn_setup->rsvd_tgt_qpn = rsvd_qpn;
+		return FI_SUCCESS;
+	}
+
+	/* An existing XRC target was not specified, create XRC TGT
+	 * side of new physical connection. */
+	fi_ibv_msg_ep_get_qp_attr(ep, NULL,
+			(struct ibv_qp_init_attr *)&attr_ex);
+	attr_ex.qp_type = IBV_QPT_XRC_RECV;
+	attr_ex.qp_context = ep;
+	attr_ex.comp_mask = IBV_QP_INIT_ATTR_PD | IBV_QP_INIT_ATTR_XRCD;
+	attr_ex.pd = domain->pd;
+	attr_ex.xrcd = domain->xrc.xrcd;
+	if (rdma_create_qp_ex(ep->tgt_id, &attr_ex)) {
+		VERBS_INFO_ERRNO(FI_LOG_EP_CTRL,
+				 "Physical XRC TGT QP, rdma_create_ep_ex()",
+				 errno);
+		return -errno;
+	}
+	ep->tgt_ibv_qp = ep->tgt_id->qp;
+
+	return FI_SUCCESS;
+}
+
+static int fi_ibv_put_tgt_qp(struct fi_ibv_ep *ep)
+{
+	int ret;
+
+	if (!ep->tgt_ibv_qp)
+		return FI_SUCCESS;
+
+	/* The kernel will not destroy the detached TGT QP until all
+	 * shared opens have called ibv_destroy_qp. */
+	ret = ibv_destroy_qp(ep->tgt_ibv_qp);
+	if (ret) {
+		VERBS_INFO_ERRNO(FI_LOG_EP_CTRL,
+				 "Close XRC TGT QP, ibv_destroy_qp()", errno);
+		return -errno;
+	}
+	ep->tgt_ibv_qp = NULL;
+
+	return FI_SUCCESS;
+}
+
+int fi_ibv_ep_destroy_xrc_qp(struct fi_ibv_ep *ep)
+{
+	struct fi_ibv_domain *domain = fi_ibv_msg_ep_to_domain(ep);
+
+	if (ep->ibv_qp) {
+		fastlock_acquire(&domain->xrc.ini_mgmt_lock);
+		fi_ibv_put_shared_ini_conn(ep);
+		fastlock_release(&domain->xrc.ini_mgmt_lock);
+	}
+	if (ep->id) {
+		rdma_destroy_id(ep->id);
+		ep->id = NULL;
+	}
+	if (ep->tgt_ibv_qp)
+		fi_ibv_put_tgt_qp(ep);
+
+	if (ep->tgt_id) {
+		rdma_destroy_id(ep->tgt_id);
+		ep->tgt_id = NULL;
+	}
+	return 0;
+}
+
+static int fi_ibv_ini_conn_compare(struct ofi_rbmap *map, void *key, void *data)
+{
+	struct fi_ibv_ini_shared_conn *ini_conn = data;
+	struct fi_ibv_ini_conn_key *_key = key;
+	int ret;
+
+	assert(_key->addr->sa_family == ini_conn->peer_addr->sa_family);
+
+	/* Only interested in the interface address and TX CQ */
+	switch (_key->addr->sa_family) {
+	case AF_INET:
+		ret = memcmp(&ofi_sin_addr(_key->addr),
+			     &ofi_sin_addr(ini_conn->peer_addr),
+			     sizeof(ofi_sin_addr(_key->addr)));
+		break;
+	case AF_INET6:
+		ret = memcmp(&ofi_sin6_addr(_key->addr),
+			     &ofi_sin6_addr(ini_conn->peer_addr),
+			     sizeof(ofi_sin6_addr(_key->addr)));
+		break;
+	default:
+		VERBS_WARN(FI_LOG_FABRIC, "Unsupported address format\n");
+		assert(0);
+		return -FI_EINVAL;
+	}
+	if (ret)
+		return ret;
+
+	return _key->tx_cq < ini_conn->tx_cq ?
+			-1 : _key->tx_cq > ini_conn->tx_cq;
+}
+
+int fi_ibv_domain_xrc_init(struct fi_ibv_domain *domain)
+{
+	struct ibv_xrcd_init_attr attr;
+	int ret;
+
+	domain->xrc.xrcd_fd = -1;
+	if (fi_ibv_gl_data.msg.xrcd_filename) {
+		domain->xrc.xrcd_fd = open(fi_ibv_gl_data.msg.xrcd_filename,
+				       O_CREAT, S_IWUSR | S_IRUSR);
+		if (domain->xrc.xrcd_fd < 0) {
+			VERBS_INFO_ERRNO(FI_LOG_DOMAIN,
+					 "XRCD file open", errno);
+			return -errno;
+		}
+	}
+
+	attr.comp_mask = IBV_XRCD_INIT_ATTR_FD | IBV_XRCD_INIT_ATTR_OFLAGS;
+	attr.fd = domain->xrc.xrcd_fd;
+	attr.oflags = O_CREAT;
+	domain->xrc.xrcd = ibv_open_xrcd(domain->verbs, &attr);
+	if (!domain->xrc.xrcd) {
+		ret = -errno;
+		VERBS_INFO_ERRNO(FI_LOG_DOMAIN, "ibv_open_xrcd", errno);
+		goto xrcd_err;
+	}
+
+	fastlock_init(&domain->xrc.ini_mgmt_lock);
+	domain->xrc.ini_conn_rbmap = calloc(1,
+			sizeof(*domain->xrc.ini_conn_rbmap));
+
+	if (!domain->xrc.ini_conn_rbmap) {
+		ret = -ENOMEM;
+		VERBS_INFO_ERRNO(FI_LOG_DOMAIN, "XRC INI QP RB Tree", -ret);
+		goto rbmap_err;
+	}
+	domain->xrc.ini_conn_rbmap->compare = &fi_ibv_ini_conn_compare;
+	ofi_rbmap_init(domain->xrc.ini_conn_rbmap);
+
+	domain->use_xrc = 1;
+	return 0;
+
+rbmap_err:
+	(void)ibv_close_xrcd(domain->xrc.xrcd);
+xrcd_err:
+	close(domain->xrc.xrcd_fd);
+	domain->xrc.xrcd_fd = -1;
+	return ret;
+}
+
+int fi_ibv_domain_xrc_cleanup(struct fi_ibv_domain *domain)
+{
+	int ret;
+
+	assert(domain->xrc.xrcd);
+
+	/* All endpoint and hence XRC INI QP should be closed */
+	if (domain->xrc.ini_conn_rbmap->root !=
+			&domain->xrc.ini_conn_rbmap->sentinel) {
+		VERBS_WARN(FI_LOG_DOMAIN, "XRC domain busy\n");
+		return -FI_EBUSY;
+	}
+
+	ret = ibv_close_xrcd(domain->xrc.xrcd);
+	if (ret) {
+		VERBS_INFO_ERRNO(FI_LOG_DOMAIN, "ibv_close_xrcd", ret);
+		return -ret;
+	}
+	if (domain->xrc.xrcd_fd > 0) {
+		close(domain->xrc.xrcd_fd);
+		domain->xrc.xrcd_fd = 0;
+	}
+
+	ofi_rbmap_cleanup(domain->xrc.ini_conn_rbmap);
+	fastlock_destroy(&domain->xrc.ini_mgmt_lock);
+
+	return 0;
+}
+
+#else /* INCLUDE_VERBS_XRC */
+
+int fi_ibv_domain_xrc_init(struct fi_ibv_domain *domain)
+{
+	/* This function should not be called if XRC is not enabled */
+	assert(0);
+	return -FI_ENOSYS;
+}
+
+int fi_ibv_domain_xrc_cleanup(struct fi_ibv_domain *domain)
+{
+	/* This function should not be called if XRC is not enabled */
+	assert(0);
+	return -FI_ENOSYS;
+}
+#endif

--- a/prov/verbs/src/verbs_ep.c
+++ b/prov/verbs/src/verbs_ep.c
@@ -36,6 +36,16 @@
 
 #define VERBS_RESOLVE_TIMEOUT 2000	// ms
 
+static struct fi_ops_msg fi_ibv_srq_msg_ops;
+
+static inline int fi_ibv_msg_ep_cmdata_size(void)
+{
+	if (fi_ibv_using_xrc())
+		return VERBS_CM_DATA_SIZE - sizeof(struct fi_ibv_xrc_cm_data);
+	else
+		return VERBS_CM_DATA_SIZE;
+}
+
 static int fi_ibv_ep_getopt(fid_t fid, int level, int optname,
 			    void *optval, size_t *optlen)
 {
@@ -45,7 +55,7 @@ static int fi_ibv_ep_getopt(fid_t fid, int level, int optname,
 		case FI_OPT_CM_DATA_SIZE:
 			if (*optlen < sizeof(size_t))
 				return -FI_ETOOSMALL;
-			*((size_t *) optval) = VERBS_CM_DATA_SIZE;
+			*((size_t *) optval) = fi_ibv_msg_ep_cmdata_size();
 			*optlen = sizeof(size_t);
 			return 0;
 		default:
@@ -131,6 +141,26 @@ static void fi_ibv_free_ep(struct fi_ibv_ep *ep)
 	free(ep);
 }
 
+#ifdef INCLUDE_VERBS_XRC
+static inline void fi_ibv_ep_xrc_close(struct fi_ibv_ep *ep)
+{
+	fi_ibv_ep_destroy_xrc_qp(ep);
+	if (ep->conn_setup)
+		fi_ibv_free_xrc_conn_setup(ep);
+	if (ep->tgt_info)
+		fi_freeinfo(ep->tgt_info);
+}
+
+#else /* INCLUDE_VERBS_XRC */
+
+static inline void fi_ibv_ep_xrc_close(struct fi_ibv_ep *ep)
+{
+	/* Should not be callable if XRC is disabled */
+	assert(0);
+}
+
+#endif /* INCLUDE_VERBS_XRC */
+
 static int fi_ibv_ep_close(fid_t fid)
 {
 	int ret;
@@ -140,7 +170,10 @@ static int fi_ibv_ep_close(fid_t fid)
 
 	switch (ep->util_ep.type) {
 	case FI_EP_MSG:
-		rdma_destroy_ep(ep->id);
+		if (fi_ibv_using_xrc())
+			fi_ibv_ep_xrc_close(ep);
+		else
+			rdma_destroy_ep(ep->id);
 		fi_ibv_cleanup_cq(ep);
 		break;
 	case FI_EP_DGRAM:
@@ -173,6 +206,27 @@ static int fi_ibv_ep_close(fid_t fid)
 	return 0;
 }
 
+#ifdef INCLUDE_VERBS_XRC
+
+static inline int fi_ibv_ep_xrc_set_tgt_chan(struct fi_ibv_ep *ep)
+{
+	if (ep->tgt_id)
+		return rdma_migrate_id(ep->tgt_id, ep->eq->channel);
+
+	return FI_SUCCESS;
+}
+
+#else /* INCLUDE_VERBS_XRC */
+
+static inline int fi_ibv_ep_xrc_set_tgt_chan(struct fi_ibv_ep *ep)
+{
+	/* Should not be callable if XRC is disabled */
+	assert(0);
+	return -FI_ENOSYS;
+}
+
+#endif /* INCLUDE_VERBS_XRC */
+
 static int fi_ibv_ep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 {
 	struct fi_ibv_ep *ep;
@@ -199,6 +253,11 @@ static int fi_ibv_ep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 			ret = rdma_migrate_id(ep->id, ep->eq->channel);
 			if (ret)
 				return -errno;
+			if (fi_ibv_using_xrc()) {
+				ret = fi_ibv_ep_xrc_set_tgt_chan(ep);
+				if (ret)
+					return -errno;
+			}
 			break;
 		case FI_CLASS_SRX_CTX:
 			ep->srq_ep = container_of(bfid, struct fi_ibv_srq_ep, ep_fid.fid);
@@ -327,12 +386,154 @@ static int fi_ibv_create_dgram_ep(struct fi_ibv_domain *domain, struct fi_ibv_ep
 	return 0;
 }
 
+#ifdef INCLUDE_VERBS_XRC
+
+static int fi_ibv_process_xrc_preposted(struct fi_ibv_srq_ep *srq_ep)
+{
+	struct fi_ibv_xrc_srx_prepost *recv;
+	struct slist_entry *entry;
+	int ret;
+
+	while (!slist_empty(&srq_ep->prepost_list)) {
+		entry = slist_remove_head(&srq_ep->prepost_list);
+		recv = container_of(entry, struct fi_ibv_xrc_srx_prepost,
+				    prepost_entry);
+		ret = fi_recv(&srq_ep->ep_fid, recv->buf, recv->len,
+			      recv->desc, recv->src_addr, recv->context);
+		free(recv);
+		if (ret) {
+			VERBS_INFO_ERRNO(FI_LOG_DOMAIN, "fi_recv", errno);
+			return -errno;
+		}
+	}
+	return FI_SUCCESS;
+}
+
+static int fi_ibv_ep_enable_xrc(struct fi_ibv_ep *ep)
+{
+	struct fi_ibv_srq_ep *srq_ep = ep->srq_ep;
+	struct fi_ibv_domain *domain = container_of(ep->util_ep.rx_cq->domain,
+					    struct fi_ibv_domain, util_domain);
+	struct fi_ibv_cq *cq = container_of(ep->util_ep.rx_cq,
+					    struct fi_ibv_cq, util_cq);
+	struct ibv_srq_init_attr_ex attr;
+	ssize_t ret;
+
+	/* XRC EP additional initialization */
+	dlist_init(&ep->ini_conn_entry);
+	ep->conn_state = FI_IBV_XRC_UNCONNECTED;
+
+	srq_ep->pp_fastlock_acquire(&srq_ep->prepost_lock);
+	if (srq_ep->srq) {
+		/*
+		 * Multiple endpoints bound to the same XRC SRX context have
+		 * the restriction that they must be bound to the same RX CQ
+		 */
+		if (!cq->xrc_srq_ep || srq_ep->srq != cq->xrc_srq_ep->srq) {
+			ep->srq_ep->pp_fastlock_release(&srq_ep->prepost_lock);
+			VERBS_WARN(FI_LOG_EP_CTRL, "SRX_CTX/CQ mismatch\n");
+			return -FI_EINVAL;
+		}
+		ibv_get_srq_num(srq_ep->srq, &ep->srqn);
+		ret = FI_SUCCESS;
+		goto done;
+	}
+
+	memset(&attr, 0, sizeof(attr));
+	attr.attr.max_wr = srq_ep->max_recv_wr;
+	attr.attr.max_sge = srq_ep->max_sge;
+	attr.comp_mask = IBV_SRQ_INIT_ATTR_TYPE | IBV_SRQ_INIT_ATTR_XRCD |
+			 IBV_SRQ_INIT_ATTR_CQ | IBV_SRQ_INIT_ATTR_PD;
+	attr.srq_type = IBV_SRQT_XRC;
+	attr.xrcd = domain->xrc.xrcd;
+	attr.cq = cq->cq;
+	attr.pd = domain->pd;
+
+	srq_ep->srq = ibv_create_srq_ex(domain->verbs, &attr);
+	if (!srq_ep->srq) {
+		VERBS_INFO_ERRNO(FI_LOG_DOMAIN, "ibv_create_srq_ex", errno);
+		ret = -errno;
+		goto done;
+	}
+	cq->xrc_srq_ep = srq_ep;
+	ibv_get_srq_num(srq_ep->srq, &ep->srqn);
+
+	/* Swap functions since locking is no longer required */
+	srq_ep->ep_fid.msg = &fi_ibv_srq_msg_ops;
+	ret = fi_ibv_process_xrc_preposted(srq_ep);
+done:
+	ep->srq_ep->pp_fastlock_release(&srq_ep->prepost_lock);
+
+	return ret;
+}
+
+#else /* INCLUDE_VERBS_XRC */
+
+static int fi_ibv_ep_enable_xrc(struct fi_ibv_ep *ep)
+{
+	/* Should not be callable if XRC disabled */
+	assert(0);
+	return -FI_ENOSYS;
+}
+
+#endif
+
+void fi_ibv_msg_ep_get_qp_attr(struct fi_ibv_ep *ep,
+			       struct fi_ibv_domain **domain,
+			       struct ibv_qp_init_attr *attr)
+{
+	struct fi_ibv_domain *_domain;
+
+	if (ep->util_ep.tx_cq) {
+		struct fi_ibv_cq *cq = container_of(ep->util_ep.tx_cq,
+						    struct fi_ibv_cq, util_cq);
+
+		attr->cap.max_send_wr = ep->info->tx_attr->size;
+		attr->cap.max_send_sge = ep->info->tx_attr->iov_limit;
+		attr->send_cq = cq->cq;
+		_domain = container_of(ep->util_ep.tx_cq->domain, struct fi_ibv_domain,
+				      util_domain);
+	} else {
+		struct fi_ibv_cq *cq =
+			container_of(ep->util_ep.rx_cq, struct fi_ibv_cq, util_cq);
+
+		attr->send_cq = cq->cq;
+		_domain = container_of(ep->util_ep.rx_cq->domain, struct fi_ibv_domain,
+				      util_domain);
+	}
+
+	if (ep->util_ep.rx_cq) {
+		struct fi_ibv_cq *cq =
+			container_of(ep->util_ep.rx_cq, struct fi_ibv_cq, util_cq);
+
+		attr->cap.max_recv_wr = ep->info->rx_attr->size;
+		attr->cap.max_recv_sge = ep->info->rx_attr->iov_limit;
+		attr->recv_cq = cq->cq;
+	} else {
+		struct fi_ibv_cq *cq =
+			container_of(ep->util_ep.tx_cq, struct fi_ibv_cq, util_cq);
+
+		attr->recv_cq = cq->cq;
+	}
+	attr->cap.max_inline_data = ep->info->tx_attr->inject_size;
+	attr->qp_type = IBV_QPT_RC;
+	attr->sq_sig_all = 1;
+
+	if (ep->srq_ep) {
+		attr->srq = ep->srq_ep->srq;
+		/* Recieve posts are done to SRQ not QP RQ */
+		attr->cap.max_recv_wr = 0;
+	}
+	if (domain)
+		*domain = _domain;
+}
+
+
 static int fi_ibv_ep_enable(struct fid_ep *ep_fid)
 {
 	struct ibv_qp_init_attr attr = { 0 };
 	struct fi_ibv_domain *domain;
 	struct fi_ibv_ep *ep;
-	struct ibv_pd *pd;
 	int ret;
 
 	ep = container_of(ep_fid, struct fi_ibv_ep, util_ep.ep_fid);
@@ -362,66 +563,35 @@ static int fi_ibv_ep_enable(struct fid_ep *ep_fid)
 			   "capabilities enabled. (FI_RECV)\n");
 		return -FI_ENOCQ;
 	}
-
-	if (ep->util_ep.tx_cq) {
-		struct fi_ibv_cq *cq =
-			container_of(ep->util_ep.tx_cq, struct fi_ibv_cq, util_cq);
-
-		attr.cap.max_send_wr = ep->info->tx_attr->size;
-		attr.cap.max_send_sge = ep->info->tx_attr->iov_limit;
-		attr.send_cq = cq->cq;
-		domain = container_of(ep->util_ep.tx_cq->domain, struct fi_ibv_domain,
-				      util_domain);
-		pd = domain->pd;
-	} else {
-		struct fi_ibv_cq *cq =
-			container_of(ep->util_ep.rx_cq, struct fi_ibv_cq, util_cq);
-
-		attr.send_cq = cq->cq;
-		domain = container_of(ep->util_ep.rx_cq->domain, struct fi_ibv_domain,
-				      util_domain);
-		pd = domain->pd;
-	}
-
-	if (ep->util_ep.rx_cq) {
-		struct fi_ibv_cq *cq =
-			container_of(ep->util_ep.rx_cq, struct fi_ibv_cq, util_cq);
-
-		attr.cap.max_recv_wr = ep->info->rx_attr->size;
-		attr.cap.max_recv_sge = ep->info->rx_attr->iov_limit;
-		attr.recv_cq = cq->cq;
-	} else {		
-		struct fi_ibv_cq *cq =
-			container_of(ep->util_ep.tx_cq, struct fi_ibv_cq, util_cq);
-
-		attr.recv_cq = cq->cq;
-	}
-
-	attr.cap.max_inline_data = ep->info->tx_attr->inject_size;
+	fi_ibv_msg_ep_get_qp_attr(ep, &domain, &attr);
 
 	switch (ep->util_ep.type) {
 	case FI_EP_MSG:
 		if (ep->srq_ep) {
-			attr.srq = ep->srq_ep->srq;
-			/* Use of SRQ, no need to allocate recv_wr entries in the QP */
-			attr.cap.max_recv_wr = 0;
-
 			/* Override the default ops to prevent the user from posting WRs to a
 			 * QP where a SRQ is attached to */
 			ep->util_ep.ep_fid.msg = &fi_ibv_msg_srq_ep_msg_ops;
+
+			if (domain->use_xrc)
+				return fi_ibv_ep_enable_xrc(ep);
+		} else if (fi_ibv_using_xrc()) {
+			VERBS_WARN(FI_LOG_EP_CTRL, "XRC EP_MSG not bound "
+				   "to srx_context\n");
+			return -FI_EINVAL;
 		}
 
-		attr.qp_type = IBV_QPT_RC;
-		attr.sq_sig_all = 1;
 		attr.qp_context = ep;
-
-		ret = rdma_create_qp(ep->id, pd, &attr);
+		ret = rdma_create_qp(ep->id, domain->pd, &attr);
 		if (ret) {
 			ret = -errno;
-			VERBS_WARN(FI_LOG_EP_CTRL, "Unable to create rdma qp: %s (%d)\n",
+			VERBS_WARN(FI_LOG_EP_CTRL,
+				   "Unable to create rdma qp: %s (%d)\n",
 				   fi_strerror(-ret), -ret);
 			return ret;
 		}
+
+		/* Allow shared XRC INI QP not controlled by RDMA CM
+		 * to share same post functions as RC QP. */
 		ep->ibv_qp = ep->id->qp;
 		break;
 	case FI_EP_DGRAM:
@@ -566,6 +736,19 @@ int fi_ibv_open_ep(struct fid_domain *domain, struct fi_info *info,
 	struct fi_info *fi;
 	int ret;
 
+	size_t len = OFI_ADDRSTRLEN;
+	char buf[len];
+
+	if (info->src_addr) {
+		ofi_straddr(buf, &len, info->addr_format, info->src_addr);
+		VERBS_DBG(FI_LOG_FABRIC, "Open_EP src addr: %s\n", buf);
+	}
+	if (info->dest_addr) {
+		len = OFI_ADDRSTRLEN;
+		ofi_straddr(buf, &len, info->addr_format, info->dest_addr);
+		VERBS_DBG(FI_LOG_FABRIC, "Open_EP dest addr: %s\n", buf);
+	}
+
 	dom = container_of(domain, struct fi_ibv_domain,
 			   util_domain.domain_fid);
 	/* strncmp is used here, because the function is used
@@ -623,7 +806,10 @@ int fi_ibv_open_ep(struct fid_domain *domain, struct fi_info *info,
 			ep->util_ep.ep_fid.msg = &fi_ibv_msg_ep_msg_ops;
 			ep->util_ep.ep_fid.rma = &fi_ibv_msg_ep_rma_ops;		
 		}
-		ep->util_ep.ep_fid.cm = &fi_ibv_msg_ep_cm_ops;
+		if (dom->use_xrc)
+			ep->util_ep.ep_fid.cm = &fi_ibv_msg_xrc_ep_cm_ops;
+		else
+			ep->util_ep.ep_fid.cm = &fi_ibv_msg_ep_cm_ops;
 		ep->util_ep.ep_fid.atomic = &fi_ibv_msg_ep_atomic_ops;
 
 		if (!info->handle) {
@@ -631,9 +817,19 @@ int fi_ibv_open_ep(struct fid_domain *domain, struct fi_info *info,
 			if (ret)
 				goto err2;
 		} else if (info->handle->fclass == FI_CLASS_CONNREQ) {
-			connreq = container_of(info->handle, struct fi_ibv_connreq, handle);
-			ep->id = connreq->id;
-			ep->ibv_qp = ep->id->qp;
+			connreq = container_of(info->handle,
+					       struct fi_ibv_connreq, handle);
+			if (fi_ibv_using_xrc()) {
+				if (!connreq->xrc.is_reciprocal) {
+					ret = fi_ibv_process_xrc_connreq(ep,
+								connreq);
+					if (ret)
+						goto err2;
+				}
+			} else {
+				ep->id = connreq->id;
+				ep->ibv_qp = ep->id->qp;
+			}
 		} else if (info->handle->fclass == FI_CLASS_PEP) {
 			pep = container_of(info->handle, struct fi_ibv_pep, pep_fid.fid);
 			ep->id = pep->id;
@@ -702,6 +898,22 @@ static int fi_ibv_pep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
 		return -FI_EINVAL;
 
 	pep->eq = container_of(bfid, struct fi_ibv_eq, eq_fid.fid);
+	/*
+	 * This is a restrictive solution that enables an XRC EP to
+	 * inform it's peer the port that should be used in making the
+	 * reciprocal connection request. While it meets RXM requirements
+	 * it limits an EQ to a single passive endpoint. TODO: implement
+	 * a more general solution.
+	 */
+	if (fi_ibv_using_xrc()) {
+	       if (pep->eq->pep_port) {
+			VERBS_WARN(FI_LOG_EP_CTRL,
+				   "XRC limits EQ binding to a single PEP\n");
+			return -FI_EINVAL;
+	       }
+	       pep->eq->pep_port = ntohs(rdma_get_src_port(pep->id));
+	}
+
 	ret = rdma_migrate_id(pep->id, pep->eq->channel);
 	if (ret)
 		return -errno;
@@ -780,6 +992,13 @@ int fi_ibv_passive_ep(struct fid_fabric *fabric, struct fi_info *info,
 	if (!(_pep->info = fi_dupinfo(info))) {
 		ret = -FI_ENOMEM;
 		goto err1;
+	}
+
+	/* Need to be able to make reciprocal XRC connections */
+	if (fi_ibv_using_xrc() && _pep->info->dest_addr) {
+		free(_pep->info->dest_addr);
+		_pep->info->dest_addr = NULL;
+		_pep->info->dest_addrlen = 0;
 	}
 
 	ret = rdma_create_id(NULL, &_pep->id, &_pep->pep_fid.fid, RDMA_PS_TCP);
@@ -910,7 +1129,7 @@ fi_ibv_srq_ep_recv(struct fid_ep *ep_fid, void *buf, size_t len,
 
 static ssize_t
 fi_ibv_srq_ep_recvv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
-                 size_t count, fi_addr_t src_addr, void *context)
+		    size_t count, fi_addr_t src_addr, void *context)
 {
 	struct fi_msg msg = {
 		.msg_iov = iov,
@@ -936,19 +1155,102 @@ static struct fi_ops_msg fi_ibv_srq_msg_ops = {
 	.injectdata = fi_no_msg_injectdata,
 };
 
+/*
+ * XRC SRQ semantics differ from basic SRQ semantics in that the SRQ not the
+ * QP selects which CQ will be used for receive completions. An artifact of
+ * this is that the XRC SRQ can not be created until a CQ is bound to the
+ * endpoint. This routine will be swapped out when the first endpoint bound
+ * to the shared receive context is enabled.
+ */
+static ssize_t
+fi_ibv_xrc_srq_ep_prepost_recv(struct fid_ep *ep_fid, void *buf, size_t len,
+			void *desc, fi_addr_t src_addr, void *context)
+{
+	struct fi_ibv_srq_ep *ep =
+		container_of(ep_fid, struct fi_ibv_srq_ep, ep_fid);
+	struct fi_ibv_xrc_srx_prepost *recv;
+	ssize_t ret;
+
+	ep->pp_fastlock_acquire(&ep->prepost_lock);
+
+	/* Handle race that can occur when SRQ is created and pre-post
+	 * receive message function is swapped out. */
+	if (ep->srq) {
+		ep->pp_fastlock_release(&ep->prepost_lock);
+		return fi_ibv_handle_post(fi_recv(ep_fid, buf, len, desc,
+						 src_addr, context));
+	}
+
+	/* The only software error that can occur is overflow */
+	if (OFI_UNLIKELY(ep->prepost_count >= ep->max_recv_wr)) {
+		ret = -FI_EAVAIL;
+		goto done;
+	}
+
+	recv = calloc(1, sizeof(*recv));
+	if (OFI_UNLIKELY(!recv)) {
+		ret = -FI_EAGAIN;
+		goto done;
+	}
+
+	recv->buf = buf;
+	recv->desc = desc;
+	recv->src_addr = src_addr;
+	recv->len = len;
+	recv->context = context;
+	ep->prepost_count++;
+	slist_insert_tail(&recv->prepost_entry, &ep->prepost_list);
+	ret = FI_SUCCESS;
+done:
+	ep->pp_fastlock_release(&ep->prepost_lock);
+	return ret;
+}
+
+static struct fi_ops_msg fi_ibv_xrc_srq_msg_ops = {
+	.size = sizeof(struct fi_ops_msg),
+	.recv = fi_ibv_xrc_srq_ep_prepost_recv,
+	.recvv = fi_no_msg_recvv,		/* Not used by RXM */
+	.recvmsg = fi_no_msg_recvmsg,		/* Not used by RXM */
+	.send = fi_no_msg_send,
+	.sendv = fi_no_msg_sendv,
+	.sendmsg = fi_no_msg_sendmsg,
+	.inject = fi_no_msg_inject,
+	.senddata = fi_no_msg_senddata,
+	.injectdata = fi_no_msg_injectdata,
+};
+
+static void fi_ibv_cleanup_prepost_bufs(struct fi_ibv_srq_ep *srq_ep)
+{
+	struct fi_ibv_xrc_srx_prepost *recv;
+	struct slist_entry *entry;
+
+	while (!slist_empty(&srq_ep->prepost_list)) {
+		entry = slist_remove_head(&srq_ep->prepost_list);
+		recv = container_of(entry, struct fi_ibv_xrc_srx_prepost,
+				    prepost_entry);
+		free(recv);
+	}
+}
+
 static int fi_ibv_srq_close(fid_t fid)
 {
 	struct fi_ibv_srq_ep *srq_ep;
 	int ret;
 
 	srq_ep = container_of(fid, struct fi_ibv_srq_ep, ep_fid.fid);
-	ret = ibv_destroy_srq(srq_ep->srq);
-	if (ret) {
-		VERBS_WARN(FI_LOG_EP_CTRL,
-			   "Cannot destroy SRQ rc=%d\n", ret);
-		return ret;
+	if (srq_ep->srq) {
+		ret = ibv_destroy_srq(srq_ep->srq);
+		if (ret) {
+			VERBS_WARN(FI_LOG_EP_CTRL,
+				   "Cannot destroy SRQ rc=%d\n", ret);
+			return ret;
+		}
 	}
 
+	if (srq_ep->domain->use_xrc) {
+		fi_ibv_cleanup_prepost_bufs(srq_ep);
+		fastlock_destroy(&srq_ep->prepost_lock);
+	}
 	free(srq_ep);
 
 	return ret;
@@ -986,11 +1288,31 @@ int fi_ibv_srq_context(struct fid_domain *domain, struct fi_rx_attr *attr,
 	srq_ep->ep_fid.fid.context = context;
 	srq_ep->ep_fid.fid.ops = &fi_ibv_srq_ep_ops;
 	srq_ep->ep_fid.ops = &fi_ibv_srq_ep_base_ops;
-	srq_ep->ep_fid.msg = &fi_ibv_srq_msg_ops;
 	srq_ep->ep_fid.cm = &fi_ibv_srq_cm_ops;
 	srq_ep->ep_fid.rma = &fi_ibv_srq_rma_ops;
 	srq_ep->ep_fid.atomic = &fi_ibv_srq_atomic_ops;
+	srq_ep->domain = dom;
 
+	/* XRC SRQ creation is delayed until the first endpoint it is bound
+	 * to is enabled.*/
+	if (dom->use_xrc) {
+		fastlock_init(&srq_ep->prepost_lock);
+		if (dom->util_domain.threading == FI_THREAD_DOMAIN) {
+			srq_ep->pp_fastlock_acquire = ofi_fastlock_acquire_noop;
+			srq_ep->pp_fastlock_release = ofi_fastlock_release_noop;
+		} else {
+			srq_ep->pp_fastlock_acquire = ofi_fastlock_acquire;
+			srq_ep->pp_fastlock_release = ofi_fastlock_release;
+		}
+
+		slist_init(&srq_ep->prepost_list);
+		srq_ep->max_recv_wr = attr->size;
+		srq_ep->max_sge = attr->iov_limit;
+		srq_ep->ep_fid.msg = &fi_ibv_xrc_srq_msg_ops;
+		goto done;
+	}
+
+	srq_ep->ep_fid.msg = &fi_ibv_srq_msg_ops;
 	srq_init_attr.attr.max_wr = attr->size;
 	srq_init_attr.attr.max_sge = attr->iov_limit;
 
@@ -1001,10 +1323,13 @@ int fi_ibv_srq_context(struct fid_domain *domain, struct fi_rx_attr *attr,
 		goto err2;
 	}
 
+done:
 	*srq_ep_fid = &srq_ep->ep_fid;
 
 	return FI_SUCCESS;
+
 err2:
+	/* Only basic SRQ can take this path */
 	free(srq_ep);
 err1:
 	return ret;
@@ -1115,6 +1440,9 @@ fi_ibv_msg_ep_atomic_write(struct fid_ep *ep_fid, const void *buf, size_t count,
 		.wr.rdma.rkey = (uint32_t)(uintptr_t)key,
 		.send_flags = VERBS_INJECT(ep, sizeof(uint64_t)) |
 			      IBV_SEND_FENCE,
+#ifdef INCLUDE_VERBS_XRC
+		.qp_type.xrc.remote_srqn = ep->peer_srqn,
+#endif
 	};
 	size_t count_copy;
 	int ret;
@@ -1136,9 +1464,9 @@ fi_ibv_msg_ep_atomic_write(struct fid_ep *ep_fid, const void *buf, size_t count,
 
 static ssize_t
 fi_ibv_msg_ep_atomic_writev(struct fid_ep *ep,
-                        const struct fi_ioc *iov, void **desc, size_t count,
-                        fi_addr_t dest_addr, uint64_t addr, uint64_t key,
-                        enum fi_datatype datatype, enum fi_op op, void *context)
+			const struct fi_ioc *iov, void **desc, size_t count,
+			fi_addr_t dest_addr, uint64_t addr, uint64_t key,
+			enum fi_datatype datatype, enum fi_op op, void *context)
 {
 	if (OFI_UNLIKELY(iov->count != 1))
 		return -FI_E2BIG;
@@ -1149,7 +1477,7 @@ fi_ibv_msg_ep_atomic_writev(struct fid_ep *ep,
 
 static ssize_t
 fi_ibv_msg_ep_atomic_writemsg(struct fid_ep *ep_fid,
-                        const struct fi_msg_atomic *msg, uint64_t flags)
+			const struct fi_msg_atomic *msg, uint64_t flags)
 {
 	struct fi_ibv_ep *ep =
 		container_of(ep_fid, struct fi_ibv_ep, util_ep.ep_fid);
@@ -1159,6 +1487,9 @@ fi_ibv_msg_ep_atomic_writemsg(struct fid_ep *ep_fid,
 		.wr.rdma.rkey = (uint32_t)(uintptr_t)msg->rma_iov->key,
 		.send_flags = VERBS_INJECT_FLAGS(ep, sizeof(uint64_t), flags) |
 			      IBV_SEND_FENCE,
+#ifdef INCLUDE_VERBS_XRC
+		.qp_type.xrc.remote_srqn = ep->peer_srqn,
+#endif
 	};
 	size_t count_copy;
 	int ret;
@@ -1199,6 +1530,9 @@ fi_ibv_msg_ep_atomic_readwrite(struct fid_ep *ep_fid, const void *buf, size_t co
 	struct ibv_send_wr wr = {
 		.wr_id = VERBS_COMP(ep, (uintptr_t)context),
 		.send_flags = IBV_SEND_FENCE,
+#ifdef INCLUDE_VERBS_XRC
+		.qp_type.xrc.remote_srqn = ep->peer_srqn,
+#endif
 	};
 	size_t count_copy;
 	int ret;
@@ -1244,7 +1578,7 @@ fi_ibv_msg_ep_atomic_readwritev(struct fid_ep *ep, const struct fi_ioc *iov,
 	if (OFI_UNLIKELY(iov->count != 1))
 		return -FI_E2BIG;
 
-        return fi_ibv_msg_ep_atomic_readwrite(ep, iov->addr, count,
+	return fi_ibv_msg_ep_atomic_readwrite(ep, iov->addr, count,
 			desc[0], resultv->addr, result_desc[0],
 			dest_addr, addr, key, datatype, op, context);
 }
@@ -1260,6 +1594,9 @@ fi_ibv_msg_ep_atomic_readwritemsg(struct fid_ep *ep_fid,
 	struct ibv_send_wr wr = {
 		.wr_id = VERBS_COMP_FLAGS(ep, flags, (uintptr_t)msg->context),
 		.send_flags = IBV_SEND_FENCE,
+#ifdef INCLUDE_VERBS_XRC
+		.qp_type.xrc.remote_srqn = ep->peer_srqn,
+#endif
 	};
 	size_t count_copy;
 	int ret;
@@ -1317,6 +1654,9 @@ fi_ibv_msg_ep_atomic_compwrite(struct fid_ep *ep_fid, const void *buf, size_t co
 		.wr.atomic.swap = (uintptr_t)buf,
 		.wr.atomic.rkey = (uint32_t)(uintptr_t)key,
 		.send_flags = IBV_SEND_FENCE,
+#ifdef INCLUDE_VERBS_XRC
+		.qp_type.xrc.remote_srqn = ep->peer_srqn,
+#endif
 	};
 	size_t count_copy;
 	int ret;
@@ -1350,7 +1690,7 @@ fi_ibv_msg_ep_atomic_compwritev(struct fid_ep *ep, const struct fi_ioc *iov,
 	return fi_ibv_msg_ep_atomic_compwrite(ep, iov->addr, count, desc[0],
 				comparev->addr, compare_desc[0], resultv->addr,
 				result_desc[0], dest_addr, addr, key,
-                        	datatype, op, context);
+				datatype, op, context);
 }
 
 static ssize_t
@@ -1372,6 +1712,9 @@ fi_ibv_msg_ep_atomic_compwritemsg(struct fid_ep *ep_fid,
 		.wr.atomic.swap = (uintptr_t)msg->addr,
 		.wr.atomic.rkey = (uint32_t)(uintptr_t)msg->rma_iov->key,
 		.send_flags = IBV_SEND_FENCE,
+#ifdef INCLUDE_VERBS_XRC
+		.qp_type.xrc.remote_srqn = ep->peer_srqn,
+#endif
 	};
 	size_t count_copy;
 	int ret;

--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2013-2015 Intel Corporation, Inc.  All rights reserved.
+ * Copyright (c) 2018 Cray Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -57,6 +58,93 @@ fi_ibv_eq_readerr(struct fid_eq *eq, struct fi_eq_err_entry *entry,
 	ofi_eq_handle_err_entry(_eq->fab->util_fabric.fabric_fid.api_version,
 				&_eq->err, entry);
 	return sizeof(*entry);
+}
+
+#ifdef INCLUDE_VERBS_XRC
+
+void fi_ibv_eq_set_xrc_conn_tag(struct fi_ibv_ep *ep)
+{
+	fastlock_acquire(&ep->eq->xrc_idx_lock);
+	ep->conn_setup->tag = (uint32_t)ofi_idx2key(&ep->eq->conn_key_idx,
+			ofi_idx_insert(ep->eq->conn_key_map, ep));
+	fastlock_release(&ep->eq->xrc_idx_lock);
+}
+
+void fi_ibv_eq_clear_xrc_conn_tag(struct fi_ibv_ep *ep)
+{
+	int index;
+
+	fastlock_acquire(&ep->eq->xrc_idx_lock);
+	index = ofi_key2idx(&ep->eq->conn_key_idx,
+			    (uint64_t)ep->conn_setup->tag);
+	if (!ofi_idx_is_valid(ep->eq->conn_key_map, index))
+	    VERBS_WARN(FI_LOG_EQ, "Invalid XRC connection tag\n");
+	else
+		ofi_idx_remove(ep->eq->conn_key_map, index);
+	ep->conn_setup->tag = 0;
+	fastlock_release(&ep->eq->xrc_idx_lock);
+}
+
+struct fi_ibv_ep *fi_ibv_eq_xrc_conn_tag2ep(struct fi_ibv_eq *eq, uint32_t tag)
+{
+	struct fi_ibv_ep *ep;
+	int index;
+
+	fastlock_acquire(&eq->xrc_idx_lock);
+	index = ofi_key2idx(&eq->conn_key_idx, (uint64_t)tag);
+	ep = ofi_idx_lookup(eq->conn_key_map, index);
+	if (!ep)
+		VERBS_WARN(FI_LOG_FABRIC,
+			   "Invalid XRC connection tag\n");
+	fastlock_release(&eq->xrc_idx_lock);
+
+	return ep;
+}
+
+#else /* INCLUDE_VERBS_XRC */
+
+void fi_ibv_eq_set_xrc_conn_tag(struct fi_ibv_ep *ep)
+{
+	/* Should not be callable if XRC is disabled */
+	assert(0);
+}
+
+void fi_ibv_eq_clear_xrc_conn_tag(struct fi_ibv_ep *ep)
+{
+	/* Should not be callable if XRC is disabled */
+	assert(0);
+}
+
+struct fi_ibv_ep *fi_ibv_eq_xrc_conn_tag2ep(struct fi_ibv_eq *eq, uint32_t tag)
+{
+	/* Should not be callable if XRC is disabled */
+	assert(0);
+	return NULL;
+}
+
+#endif /* INCLUDE_VERBS_XRC */
+
+static int fi_ibv_eq_set_xrc_info(struct rdma_cm_event *event,
+				  struct fi_ibv_xrc_conn_info *info)
+{
+	struct fi_ibv_xrc_cm_data *remote = (struct fi_ibv_xrc_cm_data *)
+						event->param.conn.private_data;
+	int ret;
+
+	ret = fi_ibv_verify_xrc_cm_data(remote,
+					event->param.conn.private_data_len);
+	if (ret)
+		return ret;
+
+	info->is_reciprocal = remote->reciprocal;
+	info->conn_tag = ntohl(remote->tag);
+	info->port = ntohs(remote->port);
+	info->conn_data = ntohl(remote->param);
+	info->conn_param = event->param.conn;
+	info->conn_param.private_data = NULL;
+	info->conn_param.private_data_len = 0;
+
+	return FI_SUCCESS;
 }
 
 static int
@@ -123,9 +211,19 @@ fi_ibv_eq_cm_getinfo(struct fi_ibv_fabric *fab, struct rdma_cm_event *event,
 
 	connreq->handle.fclass = FI_CLASS_CONNREQ;
 	connreq->id = event->id;
+
+	if (fi_ibv_using_xrc()) {
+		ret = fi_ibv_eq_set_xrc_info(event, &connreq->xrc);
+		if (ret)
+			goto err3;
+	}
+
 	(*info)->handle = &connreq->handle;
 	fi_freeinfo(hints);
 	return 0;
+
+err3:
+	free(connreq);
 err2:
 	fi_freeinfo(*info);
 err1:
@@ -133,20 +231,286 @@ err1:
 	return ret;
 }
 
+static inline int fi_ibv_eq_copy_event_data(struct fi_eq_cm_entry *entry,
+				size_t max_dest_len, const void *priv_data,
+				size_t priv_datalen)
+{
+	const struct fi_ibv_cm_data_hdr *cm_hdr = priv_data;
+
+	size_t datalen = MIN(max_dest_len - sizeof(*entry), cm_hdr->size);
+	if (datalen)
+		memcpy(entry->data, cm_hdr->data, datalen);
+
+	return datalen;
+}
+
+#ifdef INCLUDE_VERBS_XRC
+
+static void fi_ibv_eq_skip_xrc_cm_data(const void **priv_data,
+				       size_t *priv_data_len)
+{
+	const struct fi_ibv_xrc_cm_data *cm_data = *priv_data;
+
+	*priv_data = (cm_data + 1);
+	*priv_data_len -= sizeof(*cm_data);
+}
+
+static int
+fi_ibv_eq_xrc_connreq_event(struct fi_ibv_eq *eq, struct fi_eq_cm_entry *entry,
+			    const void **priv_data, size_t *priv_datalen)
+{
+	struct fi_ibv_connreq *connreq = container_of(entry->info->handle,
+						struct fi_ibv_connreq, handle);
+	struct fi_ibv_ep *ep;
+	struct fi_ibv_xrc_cm_data cm_data;
+	int ret;
+
+	if (!connreq->xrc.is_reciprocal) {
+		fi_ibv_eq_skip_xrc_cm_data(priv_data, priv_datalen);
+		return FI_SUCCESS;
+	}
+
+	/*
+	 * Reciprocal connections are initiated and handled internally by
+	 * the provider, get the endpoint that issued the original connection
+	 * request.
+	 */
+	ep = fi_ibv_eq_xrc_conn_tag2ep(eq, connreq->xrc.conn_tag);
+	if (!ep) {
+		VERBS_WARN(FI_LOG_FABRIC,
+			   "Reciprocal XRC connection tag not found\n");
+		goto send_reject;
+	}
+	ep->tgt_id = connreq->id;
+	ep->tgt_info = fi_dupinfo(entry->info);
+	ep->tgt_id->context = &ep->util_ep.ep_fid.fid;
+	ep->info->handle = entry->info->handle;
+
+	ret = rdma_migrate_id(ep->tgt_id, ep->eq->channel);
+	if (ret) {
+		VERBS_WARN(FI_LOG_FABRIC, "Could not migrate CM ID\n");
+		goto err;
+	}
+
+	ret = fi_ibv_accept_xrc(ep, FI_IBV_RECIP_CONN, &cm_data,
+				sizeof(cm_data));
+	if (ret) {
+		VERBS_WARN(FI_LOG_FABRIC,
+			   "Reciprocal XRC Accept failed %d\n", ret);
+		goto err;
+	}
+	/* Event is handled internally and not passed to the application */
+	return -FI_EAGAIN;
+
+err:
+	fi_freeinfo(ep->tgt_info);
+	ep->tgt_info = NULL;
+
+send_reject:
+	if (rdma_reject(connreq->id, *priv_data, *priv_datalen))
+		VERBS_WARN(FI_LOG_FABRIC, "rdma_reject %d\n", -errno);
+	return -FI_EAGAIN;
+}
+
+static int
+fi_ibv_eq_xrc_conn_event(struct fi_ibv_ep *ep, struct rdma_cm_event *cma_event,
+			 struct fi_eq_cm_entry *entry)
+{
+	struct fi_ibv_xrc_conn_info xrc_info;
+	struct fi_ibv_xrc_cm_data cm_data;
+	const void *priv_data = cma_event->param.conn.private_data;
+	size_t priv_datalen = cma_event->param.conn.private_data_len;
+	int ret;
+
+	VERBS_DBG(FI_LOG_FABRIC, "EP %p INITIAL CONNECTION DONE state %d\n",
+		  ep, ep->conn_state);
+	ep->conn_state++;
+
+	/*
+	 * Original application initiated connect is done, if the passive
+	 * side of that connection initiate the reciprocal connection request
+	 * to create bidirectional connectivity.
+	 */
+	if (priv_data) {
+		ret = fi_ibv_eq_set_xrc_info(cma_event, &xrc_info);
+		if (ret) {
+			ep->conn_state--;
+			rdma_disconnect(ep->id);
+			goto err;
+		}
+		ep->peer_srqn = xrc_info.conn_data;
+		fi_ibv_ep_ini_conn_done(ep, xrc_info.conn_data,
+					xrc_info.conn_param.qp_num);
+		fi_ibv_eq_skip_xrc_cm_data(&priv_data, &priv_datalen);
+		fi_ibv_save_priv_data(ep, priv_data, priv_datalen);
+	} else {
+		fi_ibv_ep_tgt_conn_done(ep);
+		ret = fi_ibv_connect_xrc(ep, NULL, FI_IBV_RECIP_CONN, &cm_data,
+					 sizeof(cm_data));
+		if (ret) {
+			ep->conn_state--;
+			rdma_disconnect(ep->tgt_id);
+			goto err;
+		}
+	}
+err:
+	entry->info = NULL;
+	/* Event is handled internally and not passed to the application */
+	return -FI_EAGAIN;
+}
+
+static size_t
+fi_ibv_eq_xrc_recip_conn_event(struct fi_ibv_ep *ep,
+			       struct rdma_cm_event *cma_event,
+			       struct fi_eq_cm_entry *entry, size_t len)
+{
+	fid_t fid = cma_event->id->context;
+	struct fi_ibv_xrc_conn_info xrc_info;
+	int ret;
+
+	ep->conn_state++;
+
+	VERBS_DBG(FI_LOG_FABRIC, "EP %p RECIPROCAL CONNECTION DONE state %d\n",
+		  ep, ep->conn_state);
+
+	/* If this is the reciprocal active side notification */
+	if (cma_event->param.conn.private_data) {
+		ret = fi_ibv_eq_set_xrc_info(cma_event, &xrc_info);
+
+		/* Version should not change between original and reciprocal */
+		if (ret)
+			abort();
+
+		ep->peer_srqn = xrc_info.conn_data;
+		fi_ibv_ep_ini_conn_done(ep, xrc_info.conn_data,
+					xrc_info.conn_param.qp_num);
+	} else {
+			fi_ibv_ep_tgt_conn_done(ep);
+	}
+
+	/* The internal reciprocal XRC connection has completed. Return the
+	 * CONNECTED event application data associated with the original
+	 * connection. */
+	entry->fid = fid;
+	len = fi_ibv_eq_copy_event_data(entry, len,
+					ep->conn_setup->event_data,
+					ep->conn_setup->event_len);
+	entry->info = NULL;
+	return sizeof(*entry) + len;
+}
+
+static int
+fi_ibv_eq_xrc_rej_event(struct fi_ibv_eq *eq, struct rdma_cm_event *cma_event)
+{
+	struct fi_ibv_ep *ep;
+	fid_t fid = cma_event->id->context;
+	struct fi_ibv_xrc_conn_info xrc_info;
+
+	ep = container_of(fid, struct fi_ibv_ep, util_ep.ep_fid);
+
+	if (!cma_event->param.conn.private_data_len ||
+			fi_ibv_eq_set_xrc_info(cma_event, &xrc_info)) {
+		/* IB CM infrastructure reject and user CM data is not
+		 * available. Handle internally. */
+		VERBS_WARN(FI_LOG_FABRIC,
+			   "CM Reject %d\n", cma_event->status);
+		fi_ibv_ep_ini_conn_rejected(ep);
+		return -FI_EAGAIN;
+	}
+
+	fi_ibv_ep_ini_conn_rejected(ep);
+	return ep->id == cma_event->id ? FI_SUCCESS : -FI_EAGAIN;
+}
+
+static inline int
+fi_ibv_eq_xrc_connected_event(struct fi_ibv_eq *eq,
+			      struct rdma_cm_event *cma_event,
+			      struct fi_eq_cm_entry *entry, size_t len,
+			      int *acked)
+{
+	struct fi_ibv_ep *ep;
+	fid_t fid = cma_event->id->context;
+	int ret;
+
+	ep = container_of(fid, struct fi_ibv_ep, util_ep.ep_fid);
+
+	assert(ep->conn_state == FI_IBV_XRC_ORIG_CONNECTING ||
+	       ep->conn_state == FI_IBV_XRC_RECIP_CONNECTING);
+
+	if (ep->conn_state == FI_IBV_XRC_ORIG_CONNECTING)
+		return fi_ibv_eq_xrc_conn_event(ep, cma_event, entry);
+
+	ret = fi_ibv_eq_xrc_recip_conn_event(ep, cma_event, entry, len);
+
+	/* Bidirectional connection setup is complete, destroy RDMA CM
+	 * ID(s) since  RDMA CM is used for connection setup only */
+	*acked = 1;
+	rdma_ack_cm_event(cma_event);
+	fi_ibv_free_xrc_conn_setup(ep);
+
+	return ret;
+}
+
+#else /* INCLUDE_VERBS_XRC */
+
+static void
+fi_ibv_eq_skip_xrc_cm_data(const void **priv_data, size_t *priv_data_len)
+{
+	/* Should not be callable if XRC is disabled */
+	abort();
+	return;
+}
+
+static int
+fi_ibv_eq_xrc_connreq_event(struct fi_ibv_eq *eq, struct fi_eq_cm_entry *entry,
+			    const void **priv_data, size_t *priv_datalen)
+{
+	/* Should not be callable if XRC is disabled */
+	assert(0);
+	return -FI_ENOSYS;
+}
+
+static inline int
+fi_ibv_eq_xrc_connected_event(struct fi_ibv_eq *eq,
+			      struct rdma_cm_event *cma_event,
+			      struct fi_eq_cm_entry *entry, size_t len,
+			      int *acked)
+{
+	/* Should not be callable if XRC is disabled */
+	assert(0);
+	return -FI_ENOSYS;
+}
+
+static int
+fi_ibv_eq_xrc_rej_event(struct fi_ibv_eq *eq, struct rdma_cm_event *cma_event)
+{
+	/* Should not be callable if XRC is disabled */
+	assert(0);
+	return -FI_ENOSYS;
+}
+
+#endif /* INCLUDE_VERBS_XRC */
+
 static ssize_t
-fi_ibv_eq_cm_process_event(struct fi_ibv_eq *eq, struct rdma_cm_event *cma_event,
-			   uint32_t *event, struct fi_eq_cm_entry *entry, size_t len)
+fi_ibv_eq_cm_process_event(struct fi_ibv_eq *eq,
+	struct rdma_cm_event *cma_event, uint32_t *event,
+	struct fi_eq_cm_entry *entry, size_t len, int *acked)
 {
 	const struct fi_ibv_cm_data_hdr *cm_hdr;
 	size_t datalen = 0;
+	size_t priv_datalen = cma_event->param.conn.private_data_len;
+	const void *priv_data = cma_event->param.conn.private_data;
 	int ret;
 	fid_t fid = cma_event->id->context;
 	struct fi_ibv_pep *pep =
 		container_of(fid, struct fi_ibv_pep, pep_fid);
 
+	*acked = 0;
+
 	switch (cma_event->event) {
 	case RDMA_CM_EVENT_CONNECT_REQUEST:
 		*event = FI_CONNREQ;
+
 		ret = fi_ibv_eq_cm_getinfo(eq->fab, cma_event, pep->info, &entry->info);
 		if (ret) {
 			rdma_destroy_id(cma_event->id);
@@ -156,18 +520,33 @@ fi_ibv_eq_cm_process_event(struct fi_ibv_eq *eq, struct rdma_cm_event *cma_event
 			eq->err.prov_errno = ret;
 			goto err;
 		}
+
+		if (fi_ibv_using_xrc()) {
+			ret = fi_ibv_eq_xrc_connreq_event(eq, entry, &priv_data,
+							  &priv_datalen);
+			if (ret == -FI_EAGAIN)
+				return ret;
+		}
 		break;
 	case RDMA_CM_EVENT_ESTABLISHED:
 		*event = FI_CONNECTED;
-		entry->info = NULL;
-		if (cma_event->id->qp->context->device->transport_type !=
+
+		if (cma_event->id->qp &&
+		    cma_event->id->qp->context->device->transport_type !=
 		    IBV_TRANSPORT_IWARP) {
 			ret = fi_ibv_set_rnr_timer(cma_event->id->qp);
 			if (ret)
 				return ret;
 		}
+
+		if (fi_ibv_using_xrc())
+			return fi_ibv_eq_xrc_connected_event(eq, cma_event,
+							     entry, len, acked);
+		entry->info = NULL;
 		break;
 	case RDMA_CM_EVENT_DISCONNECTED:
+		if (fi_ibv_using_xrc())
+			return -FI_EAGAIN;
 		*event = FI_SHUTDOWN;
 		entry->info = NULL;
 		break;
@@ -178,6 +557,12 @@ fi_ibv_eq_cm_process_event(struct fi_ibv_eq *eq, struct rdma_cm_event *cma_event
 		eq->err.err = -cma_event->status;
 		goto err;
 	case RDMA_CM_EVENT_REJECTED:
+		if (fi_ibv_using_xrc()) {
+			ret = fi_ibv_eq_xrc_rej_event(eq, cma_event);
+			if (ret == -FI_EAGAIN)
+				return ret;
+			fi_ibv_eq_skip_xrc_cm_data(&priv_data, &priv_datalen);
+		}
 		eq->err.err = ECONNREFUSED;
 		eq->err.prov_errno = -cma_event->status;
 		if (eq->err.err_data) {
@@ -185,8 +570,8 @@ fi_ibv_eq_cm_process_event(struct fi_ibv_eq *eq, struct rdma_cm_event *cma_event
 			eq->err.err_data = NULL;
 			eq->err.err_data_size = 0;
 		}
-		if (cma_event->param.conn.private_data_len) {
-			cm_hdr = cma_event->param.conn.private_data;
+		if (priv_datalen) {
+			cm_hdr = priv_data;
 			eq->err.err_data = calloc(1, cm_hdr->size);
 			if (OFI_LIKELY(eq->err.err_data != NULL)) {
 				memcpy(eq->err.err_data, cm_hdr->data,
@@ -206,13 +591,11 @@ fi_ibv_eq_cm_process_event(struct fi_ibv_eq *eq, struct rdma_cm_event *cma_event
 	}
 
 	entry->fid = fid;
-	if (cma_event->param.conn.private_data_len) {
-		cm_hdr = cma_event->param.conn.private_data;
-		/* rdmacm has no way to track how much data is sent by peer */
-		datalen = MIN(len - sizeof(*entry), cm_hdr->size);
-		if (datalen)
-			memcpy(entry->data, cm_hdr->data, datalen);
-	}
+
+	/* rdmacm has no way to track how much data is sent by peer */
+	if (priv_datalen)
+		datalen = fi_ibv_eq_copy_event_data(entry, len, priv_data,
+						    priv_datalen);
 	return sizeof(*entry) + datalen;
 err:
 	eq->err.fid = fid;
@@ -289,6 +672,7 @@ fi_ibv_eq_read(struct fid_eq *eq_fid, uint32_t *event,
 	struct fi_ibv_eq *eq;
 	struct rdma_cm_event *cma_event;
 	ssize_t ret = 0;
+	int acked;
 
 	eq = container_of(eq_fid, struct fi_ibv_eq, eq_fid.fid);
 
@@ -303,20 +687,23 @@ fi_ibv_eq_read(struct fid_eq *eq_fid, uint32_t *event,
 		if (ret)
 			return -errno;
 
+		acked = 0;
 		if (len < sizeof(struct fi_eq_cm_entry)) {
 			ret = -FI_ETOOSMALL;
 			goto ack;
 		}
 
 		ret = fi_ibv_eq_cm_process_event(eq, cma_event, event,
-				(struct fi_eq_cm_entry *)buf, len);
+				(struct fi_eq_cm_entry *)buf, len, &acked);
 		if (ret < 0)
 			goto ack;
 
 		if (flags & FI_PEEK)
 			ret = fi_ibv_eq_write_event(eq, *event, buf, len);
 ack:
-		rdma_ack_cm_event(cma_event);
+		if (!acked)
+			rdma_ack_cm_event(cma_event);
+
 		return ret;
 	}
 
@@ -407,6 +794,13 @@ static int fi_ibv_eq_close(fid_t fid)
 	}
 
 	dlistfd_head_free(&eq->list_head);
+
+	if (fi_ibv_using_xrc()) {
+		ofi_idx_reset(eq->conn_key_map);
+		free(eq->conn_key_map);
+		fastlock_destroy(&eq->xrc_idx_lock);
+	}
+
 	fastlock_destroy(&eq->lock);
 	free(eq);
 
@@ -434,6 +828,16 @@ int fi_ibv_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 
 	_eq->fab = container_of(fabric, struct fi_ibv_fabric,
 				util_fabric.fabric_fid);
+
+	if (fi_ibv_using_xrc()) {
+		ofi_key_idx_init(&_eq->conn_key_idx, VERBS_TAG_INDEX_BITS);
+		_eq->conn_key_map = calloc(1, sizeof(*_eq->conn_key_map));
+		if (!_eq->conn_key_map) {
+			ret = -ENOMEM;
+			goto err0;
+		}
+		fastlock_init(&_eq->xrc_idx_lock);
+	}
 
 	fastlock_init(&_eq->lock);
 	ret = dlistfd_head_init(&_eq->list_head);
@@ -499,6 +903,11 @@ err2:
 	dlistfd_head_free(&_eq->list_head);
 err1:
 	fastlock_destroy(&_eq->lock);
+	if (fi_ibv_using_xrc()) {
+		fastlock_destroy(&_eq->xrc_idx_lock);
+		free(_eq->conn_key_map);
+	}
+err0:
 	free(_eq);
 	return ret;
 }

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -412,16 +412,21 @@ static inline int fi_ibv_get_qp_cap(struct ibv_context *ctx,
 		goto err1;
 	}
 
-	qp_type = (info->ep_attr->type != FI_EP_DGRAM) ?
-			    IBV_QPT_RC : IBV_QPT_UD;
+	if (fi_ibv_using_xrc() && info->ep_attr->type == FI_EP_MSG)
+		qp_type = IBV_QPT_XRC_SEND;
+	else
+		qp_type = (info->ep_attr->type != FI_EP_DGRAM) ?
+				    IBV_QPT_RC : IBV_QPT_UD;
 
 	memset(&init_attr, 0, sizeof init_attr);
 	init_attr.send_cq = cq;
-	init_attr.recv_cq = cq;
 	init_attr.cap.max_send_wr = fi_ibv_gl_data.def_tx_size;
-	init_attr.cap.max_recv_wr = fi_ibv_gl_data.def_rx_size;
 	init_attr.cap.max_send_sge = fi_ibv_gl_data.def_tx_iov_limit;
-	init_attr.cap.max_recv_sge = fi_ibv_gl_data.def_rx_iov_limit;
+	if (qp_type != IBV_QPT_XRC_SEND) {
+		init_attr.recv_cq = cq;
+		init_attr.cap.max_recv_wr = fi_ibv_gl_data.def_rx_size;
+		init_attr.cap.max_recv_sge = fi_ibv_gl_data.def_rx_iov_limit;
+	}
 	init_attr.cap.max_inline_data = fi_ibv_find_max_inline(pd, ctx, qp_type);
 	init_attr.qp_type = qp_type;
 
@@ -475,6 +480,14 @@ static int fi_ibv_get_device_attrs(struct ibv_context *ctx,
 		VERBS_INFO_ERRNO(FI_LOG_FABRIC,
 				 "ibv_query_device", errno);
 		return -errno;
+	}
+
+	if (fi_ibv_using_xrc()) {
+		if (info->ep_attr->type == FI_EP_MSG &&
+		    !(device_attr.device_cap_flags & IBV_DEVICE_XRC)) {
+			VERBS_WARN(FI_LOG_FABRIC, "XRC not supported\n");
+			return -FI_EINVAL;
+		}
 	}
 
 	info->domain_attr->cq_cnt 		= device_attr.max_cq;
@@ -1020,7 +1033,12 @@ int fi_ibv_init_info(const struct fi_info **all_infos)
 {
 	struct ibv_context **ctx_list;
 	struct fi_info *fi = NULL, *tail = NULL;
-	int ret = 0, i, num_devices;
+	const struct verbs_ep_domain *ep_type[] = {
+		&verbs_msg_domain,
+		&verbs_dgram_domain,
+		NULL,
+	};
+	int ret = 0, i, j, num_devices;
 
 	*all_infos = NULL;
 
@@ -1051,18 +1069,13 @@ int fi_ibv_init_info(const struct fi_info **all_infos)
 	}
 
 	for (i = 0; i < num_devices; i++) {
-		ret = fi_ibv_alloc_info(ctx_list[i], &fi, &verbs_msg_domain);
-		if (!ret) {
-			if (!*all_infos)
-				*all_infos = fi;
-			else
-				tail->next = fi;
-			tail = fi;
-
-			ret = fi_ibv_alloc_info(ctx_list[i], &fi,
-						&verbs_dgram_domain);
+		for (j = 0; ep_type[j]; j++) {
+			ret = fi_ibv_alloc_info(ctx_list[i], &fi, ep_type[j]);
 			if (!ret) {
-				tail->next = fi;
+				if (!*all_infos)
+					*all_infos = fi;
+				else
+					tail->next = fi;
 				tail = fi;
 			}
 		}

--- a/prov/verbs/src/verbs_msg.c
+++ b/prov/verbs/src/verbs_msg.c
@@ -96,6 +96,9 @@ fi_ibv_msg_ep_sendmsg(struct fid_ep *ep_fid, const struct fi_msg *msg, uint64_t 
 		container_of(ep_fid, struct fi_ibv_ep, util_ep.ep_fid);
 	struct ibv_send_wr wr = {
 		.wr_id = (uintptr_t)msg->context,
+#ifdef INCLUDE_VERBS_XRC
+		.qp_type.xrc.remote_srqn = ep->peer_srqn,
+#endif
 	};
 
 	if (flags & FI_REMOTE_CQ_DATA) {
@@ -118,6 +121,9 @@ fi_ibv_msg_ep_send(struct fid_ep *ep_fid, const void *buf, size_t len,
 		.wr_id = VERBS_COMP(ep, (uintptr_t)context),
 		.opcode = IBV_WR_SEND,
 		.send_flags = VERBS_INJECT(ep, len),
+#ifdef INCLUDE_VERBS_XRC
+		.qp_type.xrc.remote_srqn = ep->peer_srqn,
+#endif
 	};
 
 	return fi_ibv_send_buf(ep, &wr, buf, len, desc);
@@ -134,6 +140,9 @@ fi_ibv_msg_ep_senddata(struct fid_ep *ep_fid, const void *buf, size_t len,
 		.opcode = IBV_WR_SEND_WITH_IMM,
 		.imm_data = htonl((uint32_t)data),
 		.send_flags = VERBS_INJECT(ep, len),
+#ifdef INCLUDE_VERBS_XRC
+		.qp_type.xrc.remote_srqn = ep->peer_srqn,
+#endif
 	};
 
 	return fi_ibv_send_buf(ep, &wr, buf, len, desc);
@@ -148,6 +157,9 @@ fi_ibv_msg_ep_sendv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 	struct ibv_send_wr wr = {
 		.wr_id = (uintptr_t)context,
 		.opcode = IBV_WR_SEND,
+#ifdef INCLUDE_VERBS_XRC
+		.qp_type.xrc.remote_srqn = ep->peer_srqn,
+#endif
 	};
 
 	return fi_ibv_send_iov(ep, &wr, iov, desc, count);
@@ -162,6 +174,9 @@ static ssize_t fi_ibv_msg_ep_inject(struct fid_ep *ep_fid, const void *buf, size
 		.wr_id = VERBS_NO_COMP_FLAG,
 		.opcode = IBV_WR_SEND,
 		.send_flags = IBV_SEND_INLINE,
+#ifdef INCLUDE_VERBS_XRC
+		.qp_type.xrc.remote_srqn = ep->peer_srqn,
+#endif
 	};
 
 	return fi_ibv_send_buf_inline(ep, &wr, buf, len);
@@ -177,6 +192,9 @@ static ssize_t fi_ibv_msg_ep_injectdata(struct fid_ep *ep_fid, const void *buf, 
 		.opcode = IBV_WR_SEND_WITH_IMM,
 		.imm_data = htonl((uint32_t)data),
 		.send_flags = IBV_SEND_INLINE,
+#ifdef INCLUDE_VERBS_XRC
+		.qp_type.xrc.remote_srqn = ep->peer_srqn,
+#endif
 	};
 
 	return fi_ibv_send_buf_inline(ep, &wr, buf, len);

--- a/prov/verbs/src/verbs_rma.c
+++ b/prov/verbs/src/verbs_rma.c
@@ -56,6 +56,9 @@ fi_ibv_msg_ep_rma_write(struct fid_ep *ep_fid, const void *buf, size_t len,
 		.wr.rdma.remote_addr = addr,
 		.wr.rdma.rkey = (uint32_t)key,
 		.send_flags = VERBS_INJECT(ep, len),
+#ifdef INCLUDE_VERBS_XRC
+		.qp_type.xrc.remote_srqn = ep->peer_srqn,
+#endif
 	};
 
 	return fi_ibv_send_buf(ep, &wr, buf, len, desc);
@@ -73,6 +76,9 @@ fi_ibv_msg_ep_rma_writev(struct fid_ep *ep_fid, const struct iovec *iov, void **
 		.opcode = IBV_WR_RDMA_WRITE,
 		.wr.rdma.remote_addr = addr,
 		.wr.rdma.rkey = (uint32_t)key,
+#ifdef INCLUDE_VERBS_XRC
+		.qp_type.xrc.remote_srqn = ep->peer_srqn,
+#endif
 	};
 
 	return fi_ibv_send_iov(ep, &wr, iov, desc, count);
@@ -88,6 +94,9 @@ fi_ibv_msg_ep_rma_writemsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 		.wr_id = (uintptr_t)msg->context,
 		.wr.rdma.remote_addr = msg->rma_iov->addr,
 		.wr.rdma.rkey = (uint32_t)msg->rma_iov->key,
+#ifdef INCLUDE_VERBS_XRC
+		.qp_type.xrc.remote_srqn = ep->peer_srqn,
+#endif
 	};
 
 	if (flags & FI_REMOTE_CQ_DATA) {
@@ -112,6 +121,9 @@ fi_ibv_msg_ep_rma_read(struct fid_ep *ep_fid, void *buf, size_t len,
 		.opcode = IBV_WR_RDMA_READ,
 		.wr.rdma.remote_addr = addr,
 		.wr.rdma.rkey = (uint32_t)key,
+#ifdef INCLUDE_VERBS_XRC
+		.qp_type.xrc.remote_srqn = ep->peer_srqn,
+#endif
 	};
 
 	return fi_ibv_send_buf(ep, &wr, buf, len, desc);
@@ -130,6 +142,9 @@ fi_ibv_msg_ep_rma_readv(struct fid_ep *ep_fid, const struct iovec *iov, void **d
 		.wr.rdma.remote_addr = addr,
 		.wr.rdma.rkey = (uint32_t)key,
 		.num_sge = count,
+#ifdef INCLUDE_VERBS_XRC
+		.qp_type.xrc.remote_srqn = ep->peer_srqn,
+#endif
 	};
 
 	fi_ibv_set_sge_iov(wr.sg_list, iov, count, desc);
@@ -149,6 +164,9 @@ fi_ibv_msg_ep_rma_readmsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 		.wr.rdma.remote_addr = msg->rma_iov->addr,
 		.wr.rdma.rkey = (uint32_t)msg->rma_iov->key,
 		.num_sge = msg->iov_count,
+#ifdef INCLUDE_VERBS_XRC
+		.qp_type.xrc.remote_srqn = ep->peer_srqn,
+#endif
 	};
 
 	fi_ibv_set_sge_iov(wr.sg_list, msg->msg_iov, msg->iov_count, msg->desc);
@@ -170,6 +188,9 @@ fi_ibv_msg_ep_rma_writedata(struct fid_ep *ep_fid, const void *buf, size_t len,
 		.wr.rdma.remote_addr = addr,
 		.wr.rdma.rkey = (uint32_t)key,
 		.send_flags = VERBS_INJECT(ep, len),
+#ifdef INCLUDE_VERBS_XRC
+		.qp_type.xrc.remote_srqn = ep->peer_srqn,
+#endif
 	};
 
 	return fi_ibv_send_buf(ep, &wr, buf, len, desc);
@@ -187,6 +208,9 @@ fi_ibv_msg_ep_rma_inject_write(struct fid_ep *ep_fid, const void *buf, size_t le
 		.wr.rdma.remote_addr = addr,
 		.wr.rdma.rkey = (uint32_t)key,
 		.send_flags = IBV_SEND_INLINE,
+#ifdef INCLUDE_VERBS_XRC
+		.qp_type.xrc.remote_srqn = ep->peer_srqn,
+#endif
 	};
 
 	return fi_ibv_send_buf_inline(ep, &wr, buf, len);
@@ -202,6 +226,9 @@ fi_ibv_rma_write_fast(struct fid_ep *ep_fid, const void *buf, size_t len,
 
 	ep->wrs->rma_wr.wr.rdma.remote_addr = addr;
 	ep->wrs->rma_wr.wr.rdma.rkey = (uint32_t) key;
+#ifdef INCLUDE_VERBS_XRC
+	ep->wrs->rma_wr.qp_type.xrc.remote_srqn = ep->peer_srqn,
+#endif
 
 	ep->wrs->sge.addr = (uintptr_t) buf;
 	ep->wrs->sge.length = (uint32_t) len;
@@ -223,6 +250,9 @@ fi_ibv_msg_ep_rma_inject_writedata(struct fid_ep *ep_fid, const void *buf, size_
 		.wr.rdma.remote_addr = addr,
 		.wr.rdma.rkey = (uint32_t)key,
 		.send_flags = IBV_SEND_INLINE,
+#ifdef INCLUDE_VERBS_XRC
+		.qp_type.xrc.remote_srqn = ep->peer_srqn,
+#endif
 	};
 
 	return fi_ibv_send_buf_inline(ep, &wr, buf, len);
@@ -238,6 +268,9 @@ fi_ibv_msg_ep_rma_inject_writedata_fast(struct fid_ep *ep_fid, const void *buf, 
 		container_of(ep_fid, struct fi_ibv_ep, util_ep.ep_fid);
 	ep->wrs->rma_wr.wr.rdma.remote_addr = addr;
 	ep->wrs->rma_wr.wr.rdma.rkey = (uint32_t) key;
+#ifdef INCLUDE_VERBS_XRC
+	ep->wrs->rma_wr.qp_type.xrc.remote_srqn = ep->peer_srqn,
+#endif
 
 	ep->wrs->rma_wr.imm_data = htonl((uint32_t) data);
 	ep->wrs->rma_wr.opcode = IBV_WR_RDMA_WRITE_WITH_IMM;


### PR DESCRIPTION
The initial implementation is intended to only support usage when accompanied
with the OFI RXM provider. The code must be configured using "--with-verbs-xrc"
and then explicitly enabled via the environment variables:
FI_OFI_RXM_USE_SRX=1, FI_VERBS_USE_XRC=1.

Both XRC INI and TGT QP are shared between message endpoints. XRC INI QP are
owned by the domain and shared between MSG endpoints within a process that
is sending to endpoints on the same remote node. XRC TGT QP are owned
by the linux kernel and are shared across processes by endpoints receiving
data from the endpoints within the same remote process.

Currently the RDMA CM is used for connection management setup only and
creates only the physical INI/TGT QP. Once connections are established,
the associated RDMA CM ID is destroyed. A subsequent UD method will be
added for sending disconnect notifications.

The data path shares the RC work posting/completion code; although a shared
RX context must be used.

NOTE: The use of this code requires a small 3 line patch that permits
The RDMA CM to be used with connected QP without managing the QP as was
intended.

prov/verbs: Add additional connection establishment debug
prov/verbs: Fix INI QP connection key lookup
prov/verbs: Cleanup comments and debug code
prov/verbs: Correct NULL pointer check and convert assert to abort where needed
prov/verbs: Add additional comments for clarity
prov/verbs: Remove unused member peer_addr from endpoint
prov/verbs: Rebase changes required due to introduction of cm_hdr
prov/verbs: Fix clearing of RC QP struct to 0 when XRC is not configured

Signed-off-by: Steve Welch <swelch@systemfabricworks.com>