### PR TITLE
contrib/cray: redefine stable to nightly tag

### DIFF
--- a/contrib/cray/Jenkinsfile.verbs
+++ b/contrib/cray/Jenkinsfile.verbs
@@ -29,12 +29,7 @@ pipeline {
                 // creating git short hash
                 script {
                     GIT_SHORT_COMMIT = sh(returnStdout: true, script: "git log -n 1 --pretty=format:'%h'").trim()
-                    if (env.BRANCH_NAME == 'master' || buildingTag()) {
-                        LIBFABRIC_INSTALL = "$ROOT_BUILD_PATH/libfabric/$GIT_SHORT_COMMIT"
-                    } else {
-                        // use a temporary directory within the workspace
-                        LIBFABRIC_INSTALL = pwd tmp: true
-                    }
+                    LIBFABRIC_INSTALL = pwd tmp: true
                 }
 
                 dir ('contrib/cray/bin') {
@@ -50,26 +45,11 @@ pipeline {
             options {
                 timeout (time: 5, unit: 'MINUTES')
             }
-            failFast true
-            parallel {
-                stage("Build and install libfabric") {
-                    steps {
-                        sh './autogen.sh'
-                        sh "./configure --prefix=$LIBFABRIC_INSTALL"
-                        sh "make -j 12"
-                        sh "make install"
-                    }
-                }
-                stage("Create latest symlink") {
-                    when {
-                        expression { env.BRANCH_NAME == 'master' }
-                    }
-                    steps {
-                        script {
-                            publish env.LIBFABRIC_BUILD_PATH, "latest", "$GIT_SHORT_COMMIT"
-                        }
-                    }
-                }
+            steps {
+                sh './autogen.sh'
+                sh "./configure --prefix=$LIBFABRIC_INSTALL"
+                sh "make -j 12"
+                sh "make install"
             }
         }
         stage('Test') {
@@ -233,7 +213,27 @@ pipeline {
                     }
                 }
             }
-         }
+        }
+        stage("Install Libfabric Build") {
+            when {
+                allOf {
+                    expression { currentBuild.result == 'SUCCESS' } ;
+                    anyOf {
+                        expression { env.BRANCH_NAME == 'master' } ;
+                        buildingTag() ;
+                    }
+                }
+            }
+            environment {
+                LIBFABRIC_INSTALL_PATH="${LIBFABRIC_BUILD_PATH + '/' + GIT_SHORT_COMMIT}"
+            }
+            steps {
+                sh './autogen.sh'
+                sh "./configure --prefix=$LIBFABRIC_INSTALL_PATH"
+                sh "make -j 12"
+                sh "make install"
+            }
+        }
         stage("Deploy") {
             when {
                 allOf {
@@ -247,15 +247,19 @@ pipeline {
             options {
                 timeout (time: 5, unit: 'MINUTES')
             }
+            environment {
+                TAG_DIRECTORY = "${LIBFABRIC_BUILD_PATH + '/tags'}"
+            }
             failFast true
             parallel {
-                stage("Create stable link") {
+                stage("Create nightly link") {
                     when {
                         expression { env.BRANCH_NAME == 'master' }
                     }
                     steps {
-                        script {
-                            publish env.LIBFABRIC_BUILD_PATH, "stable", "$GIT_SHORT_COMMIT"
+                        dir (env.TAG_DIRECTORY) {
+                            sh "rm -f nightly || true"
+                            sh "ln -s ../$GIT_SHORT_COMMIT nightly"
                         }
                     }
                 }
@@ -264,8 +268,9 @@ pipeline {
                         buildingTag()
                     }
                     steps {
-                        script {
-                            publish env.LIBFABRIC_BUILD_PATH, "$BRANCH_NAME", "$GIT_SHORT_COMMIT"
+                        dir (env.TAG_DIRECTORY) {
+                            sh "rm -f $BRANCH_NAME || true"
+                            sh "ln -s ../$GIT_SHORT_COMMIT $BRANCH_NAME"
                         }
                     }
                 }
@@ -323,7 +328,6 @@ pipeline {
         }
     }
     environment {
-        GIT_SHORT_COMMIT = "$GIT_COMMIT"
         ROOT_BUILD_PATH = "/scratch/jenkins/builds"
         FABTEST_PATH = "${ROOT_BUILD_PATH + '/fabtests/stable'}"
         LIBFABRIC_BUILD_PATH = "${ROOT_BUILD_PATH + '/libfabric'}"

--- a/contrib/cray/Jenkinsfile.verbs
+++ b/contrib/cray/Jenkinsfile.verbs
@@ -89,7 +89,14 @@ pipeline {
                 }
                 stage('Functional Tests') {
                     steps {
+                        dir ("fabtests") {
+                            sh './autogen.sh'
+                            sh "./configure --with-libfabric=$LIBFABRIC_INSTALL --prefix=$FABTEST_PATH"
+                            sh "make -j12"
+                            sh "make -j12 install"
+                        }
                         tee ('fabtests.log') {
+                            sh 'srun -n 2 --ntasks-per-node 1 ldd contrib/cray/bin/fabtest_wrapper.sh'
                             sh 'srun -n 2 --ntasks-per-node=1 contrib/cray/bin/fabtest_wrapper.sh -p ${FABTEST_PATH}/bin -v -T 60'
                         }
                     }
@@ -329,7 +336,7 @@ pipeline {
     }
     environment {
         ROOT_BUILD_PATH = "/scratch/jenkins/builds"
-        FABTEST_PATH = "${ROOT_BUILD_PATH + '/fabtests/stable'}"
+        FABTEST_PATH = "${WORKSPACE + '/installs/fabtests'}"
         LIBFABRIC_BUILD_PATH = "${ROOT_BUILD_PATH + '/libfabric'}"
         OMB_BUILD_PATH = "${ROOT_BUILD_PATH + '/osu-micro-benchmarks/5.4.2/libexec/osu-micro-benchmarks/mpi'}"
         MPICH_PATH = "${ROOT_BUILD_PATH + '/mpich/3.3b3'}"

--- a/contrib/cray/bin/run_libfabric_pipeline
+++ b/contrib/cray/bin/run_libfabric_pipeline
@@ -35,7 +35,7 @@ Usage: $(basename $SOURCE) [-dhv]
 
 function set_sections_to_run {
     BUILD=false
-    TEST=false 
+    TEST=false
     UNITTEST=false
     SMOKETEST=false
     FABTEST=false
@@ -135,7 +135,7 @@ function section_start {
     echo \
 "
 ##############################################################################
-Start of \"$1\"                                                                           
+Start of \"$1\"
 ##############################################################################
 "
 }
@@ -158,13 +158,14 @@ if [[ ! -d $WORKSPACE ]] ; then
     mkdir -p $WORKSPACE
 fi
 
-pushd $DIR/../../../
+SOURCE_DIR=$DIR/../../..
+pushd $SOURCE_DIR
 
 # Start Pipeline variables
 export GIT_SHORT_COMMIT="$GIT_COMMIT"
 export LIBFABRIC_INSTALL_PATH=""
 export ROOT_BUILD_PATH="/scratch/jenkins/builds"
-export FABTEST_PATH="${ROOT_BUILD_PATH}/fabtests/stable"
+export FABTEST_PATH="${WORKSPACE}/fabtests"
 export LIBFABRIC_BUILD_PATH="${ROOT_BUILD_PATH}/libfabric"
 export OMB_BUILD_PATH="${ROOT_BUILD_PATH}/osu-micro-benchmarks/5.4.2/libexec/osu-micro-benchmarks/mpi"
 export MPICH_PATH="${ROOT_BUILD_PATH}/mpich/3.3b3"
@@ -181,8 +182,8 @@ contrib/cray/bin/setup.sh
 # End Prologue
 
 if [[ -z $LIBFABRIC ]] ; then
-    LIBFABRIC_INSTALL_PATH="${WORKSPACE}/builds/${GIT_SHORT_COMMIT}"
-else   
+    LIBFABRIC_INSTALL_PATH="${WORKSPACE}/builds/libfabric/${GIT_SHORT_COMMIT}"
+else
     LIBFABRIC_INSTALL_PATH="$LIBFABRIC"
 fi
 echo using installed libfabric @ ${LIBFABRIC_INSTALL_PATH}
@@ -230,7 +231,21 @@ fi
 if $FABTEST ; then
 section_start 'fabtests'
 ## Start Fabtests
-srun -n 2 --ntasks-per-node=1 contrib/cray/bin/fabtest_wrapper.sh -p ${FABTEST_PATH}/bin -v -T 60 | tee fabtests.log
+if [[ ! -f $FABTEST_PATH/compile-target || "$(cat $FABTEST_PATH/compile-target)" != "$LIBFABRIC_INSTALL_PATH" ]] ; then
+    pushd $SOURCE_DIR/fabtests
+    ./autogen.sh
+    ./configure --with-libfabric=$LIBFABRIC_INSTALL_PATH --prefix=$FABTEST_PATH
+    make -j12
+    make -j12 install
+    echo $LIBFABRIC_INSTALL_PATH > $FABTEST_PATH/compile-target
+    popd
+fi
+
+if [[ ! -f $FABTEST_PATH/bin/runfabtests.sh ]] ; then
+    echo run the build step to install a version of fabtests for the current build
+else
+    srun -n 2 --ntasks-per-node=1 contrib/cray/bin/fabtest_wrapper.sh -p ${FABTEST_PATH}/bin -v -T 60 | tee fabtests.log
+fi
 ## End Fabtests
 section_end 'fabtests'
 fi

--- a/contrib/cray/bin/verify_requirements.sh
+++ b/contrib/cray/bin/verify_requirements.sh
@@ -41,7 +41,6 @@ check_environment MPICH_PATH
 
 # check directories
 check_directory $ROOT_BUILD_PATH
-check_directory $FABTEST_PATH
 check_directory $OMB_BUILD_PATH
 check_directory $MPICH_PATH
 check_directory $SFT_INSTALL_PATH
@@ -50,8 +49,6 @@ check_directory $BATS_INSTALL_PATH
 ##### check prerequisite installed software packages
 # SLURM     https://slurm.schedmd.com/
 find_executable srun
-# Fabtests  https://github.com/ofiwg/libfabric
-check_executable $FABTEST_PATH/bin/runfabtests.sh
 # OMB       http://mvapich.cse.ohio-state.edu/benchmarks/
 check_executable $OMB_BUILD_PATH/pt2pt/osu_bw
 # Cray Proprietary


### PR DESCRIPTION
It isn't very useful to have a 'latest' and 'stable'
is more of a 'nightly' validation rather than 'stable'.
This commit modifies the pipeline to reflect that.

Signed-off-by: James Swaro <jswaro@cray.com>