### PR TITLE
contrib/cray: Add ubertest to test matrix

### DIFF
--- a/contrib/cray/Jenkinsfile.verbs
+++ b/contrib/cray/Jenkinsfile.verbs
@@ -103,23 +103,34 @@ pipeline {
                 }
                 stage('Functional Tests: RC') {
                     steps {
-                        tee ('fabtests.log') {
+                        tee ('fabtests-rc.log') {
                             sh 'srun -n 2 --ntasks-per-node=1 contrib/cray/bin/fabtest_wrapper.sh -p ${FABTEST_PATH}/bin -v -T 60'
+                        }
+                        tee ('ubertests-rc.log') {
+                            sh 'srun -n 2 --ntasks-per-node=1 contrib/cray/bin/fabtest_wrapper.sh -p ${FABTEST_PATH}/bin -vvv -T 60 -t complex -u all'
                         }
                     }
                     post {
                         always {
                             sh """contrib/cray/bin/parse_logfiles.sh \\
-                                    -r fabtests.log \\
-                                    -w fabtests.xml \\
+                                    -r fabtests-rc.log \\
+                                    -w fabtests-rc.xml \\
                                     fabtests \\
                                     functional.fabtests.rc.quick \\
                                     functional"""
 
+                            sh """contrib/cray/bin/parse_logfiles.sh \\
+                                    -r ubertests-rc.log \\
+                                    -w ubertests-rc.xml \\
+                                    fabtests \\
+                                    functional.fabtests.rc.uber \\
+                                    functional"""
+
+
                             step ([$class: 'XUnitBuilder',
                                thresholds: [
                                     [$class: 'FailedThreshold', unstableThreshold: '0']],
-                                    tools: [[$class: 'JUnitType', pattern: "fabtests.xml"]]])
+                                    tools: [[$class: 'JUnitType', pattern: "*-rc.xml"]]])
                         }
                     }
 		}
@@ -127,6 +138,9 @@ pipeline {
                     steps {
                         tee ('fabtests-xrc.log') {
                             sh 'srun -n 2 --ntasks-per-node=1 contrib/cray/bin/fabtest_wrapper.sh -p ${FABTEST_PATH}/bin -v -T 60 -e FI_VERBS_PREFER_XRC=1 -e FI_OFI_RXM_USE_SRX=1'
+                        }
+                        tee ('ubertests-xrc.log') {
+                            sh 'srun -n 2 --ntasks-per-node=1 contrib/cray/bin/fabtest_wrapper.sh -p ${FABTEST_PATH}/bin -vvv -T 60 -t complex -u all -e FI_VERBS_PREFER_XRC=1 -e FI_OFI_RXM_USE_SRX=1'
                         }
                     }
                     post {
@@ -138,10 +152,17 @@ pipeline {
                                     functional.fabtests.xrc.quick \\
                                     functional"""
 
+                            sh """contrib/cray/bin/parse_logfiles.sh \\
+                                    -r ubertests-xrc.log \\
+                                    -w ubertests-xrc.xml \\
+                                    fabtests \\
+                                    functional.fabtests.xrc.uber \\
+                                    functional"""
+
                             step ([$class: 'XUnitBuilder',
                                thresholds: [
                                     [$class: 'FailedThreshold', unstableThreshold: '0']],
-                                    tools: [[$class: 'JUnitType', pattern: "fabtests-xrc.xml"]]])
+                                    tools: [[$class: 'JUnitType', pattern: "*-xrc.xml"]]])
                         }
                     }
                 }


### PR DESCRIPTION
Adds fi_ubertest to test matrix for Jenkins pipeline for
additional validation of the verbs provider.

Signed-off-by: James Swaro <jswaro@cray.com>