### PR TITLE
verbs: Add defines and macros to support RHEL build

### DIFF
--- a/prov/verbs/configure.m4
+++ b/prov/verbs/configure.m4
@@ -65,6 +65,16 @@ AC_DEFUN([FI_VERBS_CONFIGURE],[
 			   [Experimental verbs features support])],
 		[])
 
+	#See if we have XRC support
+	VERBS_HAVE_XRC=0
+	AS_IF([test $verbs_ibverbs_happy -eq 1],[
+		AC_CHECK_DECL([IBV_QPT_XRC_SEND],
+			[VERBS_HAVE_XRC=1],[],
+			[#include <infiniband/verbs.h>])
+		])
+	AC_DEFINE_UNQUOTED([VERBS_HAVE_XRC],[$VERBS_HAVE_XRC],
+		[Whether infiniband/verbs.h has XRC support or not])
+
 	# Technically, verbs_ibverbs_CPPFLAGS and
 	# verbs_rdmacm_CPPFLAGS could be different, but it is highly
 	# unlikely that they ever will be.  So only list

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -76,6 +76,8 @@
 #include <infiniband/verbs_exp.h>
 #endif /* HAVE_VERBS_EXP_H */
 
+#include "fi_verbs_priv.h"
+
 #ifndef AF_IB
 #define AF_IB 27
 #endif

--- a/prov/verbs/src/fi_verbs_priv.h
+++ b/prov/verbs/src/fi_verbs_priv.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2018 Cray Inc.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef FI_VERBS_PRIV_H
+#define FI_VERBS_PRIV_H
+
+#if !VERBS_HAVE_XRC
+#define IBV_QPT_XRC_SEND 9ull
+#define IBV_QPT_XRC_RECV 10ull
+
+#define IBV_DEVICE_XRC (1 << 20)
+
+#define IBV_SRQ_INIT_ATTR_TYPE 0ull
+#define IBV_SRQ_INIT_ATTR_PD 1ull
+#define IBV_SRQ_INIT_ATTR_XRCD 2ull
+#define IBV_SRQ_INIT_ATTR_CQ 3ull
+
+#define IBV_SRQT_XRC 1ull
+#define FI_IBV_SET_REMOTE_SRQN(val)
+#define FI_VERBS_XRC_ONLY __attribute__((unused))
+
+#define ibv_get_srq_num(srq, srqn) do { } while (0)
+#define ibv_create_srq_ex(context, attr) (NULL)
+#else
+
+#define FI_IBV_SET_REMOTE_SRQN(val) \
+	.qp_type.xrc.remote_srqn = (val)
+#define FI_VERBS_XRC_ONLY
+#endif
+
+#endif

--- a/prov/verbs/src/verbs_domain_xrc.c
+++ b/prov/verbs/src/verbs_domain_xrc.c
@@ -74,6 +74,7 @@ int fi_ibv_reserve_qpn(struct fi_ibv_xrc_ep *ep, struct ibv_qp **qp)
 
 static int fi_ibv_create_ini_qp(struct fi_ibv_xrc_ep *ep)
 {
+#if VERBS_HAVE_XRC
 	struct ibv_qp_init_attr_ex attr_ex;
 	struct fi_ibv_domain *domain = fi_ibv_ep_to_domain(&ep->base_ep);
 	int ret;
@@ -93,6 +94,9 @@ static int fi_ibv_create_ini_qp(struct fi_ibv_xrc_ep *ep)
 		return ret;
 	}
 	return FI_SUCCESS;
+#else
+	return -FI_ENOSYS;
+#endif
 }
 
 static inline void fi_ibv_set_ini_conn_key(struct fi_ibv_xrc_ep *ep,
@@ -318,6 +322,7 @@ int fi_ibv_process_ini_conn(struct fi_ibv_xrc_ep *ep,int reciprocal,
 
 int fi_ibv_ep_create_tgt_qp(struct fi_ibv_xrc_ep *ep, uint32_t tgt_qpn)
 {
+#if VERBS_HAVE_XRC
 	struct ibv_qp_open_attr open_attr;
 	struct ibv_qp_init_attr_ex attr_ex;
 	struct fi_ibv_domain *domain = fi_ibv_ep_to_domain(&ep->base_ep);
@@ -375,6 +380,9 @@ int fi_ibv_ep_create_tgt_qp(struct fi_ibv_xrc_ep *ep, uint32_t tgt_qpn)
 	ep->tgt_ibv_qp = ep->tgt_id->qp;
 
 	return FI_SUCCESS;
+#else
+	return -FI_ENOSYS;
+#endif
 }
 
 static int fi_ibv_put_tgt_qp(struct fi_ibv_xrc_ep *ep)
@@ -420,6 +428,7 @@ int fi_ibv_ep_destroy_xrc_qp(struct fi_ibv_xrc_ep *ep)
 	return 0;
 }
 
+FI_VERBS_XRC_ONLY
 static int fi_ibv_ini_conn_compare(struct ofi_rbmap *map, void *key, void *data)
 {
 	struct fi_ibv_ini_shared_conn *ini_conn = data;
@@ -452,6 +461,7 @@ static int fi_ibv_ini_conn_compare(struct ofi_rbmap *map, void *key, void *data)
 			-1 : _key->tx_cq > ini_conn->tx_cq;
 }
 
+FI_VERBS_XRC_ONLY
 static int fi_ibv_domain_xrc_validate_hw(struct fi_ibv_domain *domain)
 {
 	struct ibv_device_attr attr;
@@ -467,6 +477,7 @@ static int fi_ibv_domain_xrc_validate_hw(struct fi_ibv_domain *domain)
 
 int fi_ibv_domain_xrc_init(struct fi_ibv_domain *domain)
 {
+#if VERBS_HAVE_XRC
 	struct ibv_xrcd_init_attr attr;
 	int ret;
 
@@ -518,10 +529,14 @@ xrcd_err:
 		domain->xrc.xrcd_fd = -1;
 	}
 	return ret;
+#else
+	return -FI_ENOSYS;
+#endif
 }
 
 int fi_ibv_domain_xrc_cleanup(struct fi_ibv_domain *domain)
 {
+#if VERBS_HAVE_XRC
 	int ret;
 
 	assert(domain->xrc.xrcd);
@@ -544,6 +559,6 @@ int fi_ibv_domain_xrc_cleanup(struct fi_ibv_domain *domain)
 
 	ofi_rbmap_cleanup(domain->xrc.ini_conn_rbmap);
 	fastlock_destroy(&domain->xrc.ini_mgmt_lock);
-
+#endif
 	return 0;
 }

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -1222,6 +1222,13 @@ static int fi_ibv_get_matching_info(uint32_t version,
 					   "XRC FI_EP_MSG endpoints\n");
 				continue;
 			}
+			if ((check_info->ep_attr->protocol ==
+			    FI_PROTO_RDMA_CM_IB_XRC) && !VERBS_HAVE_XRC) {
+				VERBS_INFO(FI_LOG_FABRIC,
+					   "XRC not built into provider, "
+					   "XRC FI_EP_MSG endpoints\n");
+				continue;
+			}
 
 			ret = fi_ibv_check_hints(version, hints,
 						 check_info);

--- a/prov/verbs/src/verbs_msg.c
+++ b/prov/verbs/src/verbs_msg.c
@@ -246,7 +246,7 @@ fi_ibv_msg_xrc_ep_sendmsg(struct fid_ep *ep_fid, const struct fi_msg *msg, uint6
 						base_ep.util_ep.ep_fid);
 	struct ibv_send_wr wr = {
 		.wr_id = (uintptr_t)msg->context,
-		.qp_type.xrc.remote_srqn = ep->peer_srqn,
+		FI_IBV_SET_REMOTE_SRQN(ep->peer_srqn)
 	};
 
 	if (flags & FI_REMOTE_CQ_DATA) {
@@ -269,7 +269,7 @@ fi_ibv_msg_xrc_ep_send(struct fid_ep *ep_fid, const void *buf, size_t len,
 		.wr_id = VERBS_COMP(&ep->base_ep, (uintptr_t)context),
 		.opcode = IBV_WR_SEND,
 		.send_flags = VERBS_INJECT(&ep->base_ep, len),
-		.qp_type.xrc.remote_srqn = ep->peer_srqn,
+		FI_IBV_SET_REMOTE_SRQN(ep->peer_srqn)
 	};
 
 	return fi_ibv_send_buf(&ep->base_ep, &wr, buf, len, desc);
@@ -286,7 +286,7 @@ fi_ibv_msg_xrc_ep_senddata(struct fid_ep *ep_fid, const void *buf, size_t len,
 		.opcode = IBV_WR_SEND_WITH_IMM,
 		.imm_data = htonl((uint32_t)data),
 		.send_flags = VERBS_INJECT(&ep->base_ep, len),
-		.qp_type.xrc.remote_srqn = ep->peer_srqn,
+		FI_IBV_SET_REMOTE_SRQN(ep->peer_srqn)
 	};
 
 	return fi_ibv_send_buf(&ep->base_ep, &wr, buf, len, desc);
@@ -301,7 +301,7 @@ fi_ibv_msg_xrc_ep_sendv(struct fid_ep *ep_fid, const struct iovec *iov, void **d
 	struct ibv_send_wr wr = {
 		.wr_id = (uintptr_t)context,
 		.opcode = IBV_WR_SEND,
-		.qp_type.xrc.remote_srqn = ep->peer_srqn,
+		FI_IBV_SET_REMOTE_SRQN(ep->peer_srqn)
 	};
 
 	return fi_ibv_send_iov(&ep->base_ep, &wr, iov, desc, count);
@@ -316,7 +316,7 @@ static ssize_t fi_ibv_msg_xrc_ep_inject(struct fid_ep *ep_fid, const void *buf, 
 		.wr_id = VERBS_NO_COMP_FLAG,
 		.opcode = IBV_WR_SEND,
 		.send_flags = IBV_SEND_INLINE,
-		.qp_type.xrc.remote_srqn = ep->peer_srqn,
+		FI_IBV_SET_REMOTE_SRQN(ep->peer_srqn)
 	};
 
 	return fi_ibv_send_buf_inline(&ep->base_ep, &wr, buf, len);
@@ -332,7 +332,7 @@ static ssize_t fi_ibv_msg_xrc_ep_injectdata(struct fid_ep *ep_fid, const void *b
 		.opcode = IBV_WR_SEND_WITH_IMM,
 		.imm_data = htonl((uint32_t)data),
 		.send_flags = IBV_SEND_INLINE,
-		.qp_type.xrc.remote_srqn = ep->peer_srqn,
+		FI_IBV_SET_REMOTE_SRQN(ep->peer_srqn)
 	};
 
 	return fi_ibv_send_buf_inline(&ep->base_ep, &wr, buf, len);

--- a/prov/verbs/src/verbs_rma.c
+++ b/prov/verbs/src/verbs_rma.c
@@ -289,7 +289,7 @@ fi_ibv_msg_xrc_ep_rma_write(struct fid_ep *ep_fid, const void *buf,
 		.wr.rdma.remote_addr = addr,
 		.wr.rdma.rkey = (uint32_t)key,
 		.send_flags = VERBS_INJECT(&ep->base_ep, len),
-		.qp_type.xrc.remote_srqn = ep->peer_srqn,
+		FI_IBV_SET_REMOTE_SRQN(ep->peer_srqn)
 	};
 
 	return fi_ibv_send_buf(&ep->base_ep, &wr, buf, len, desc);
@@ -307,7 +307,7 @@ fi_ibv_msg_xrc_ep_rma_writev(struct fid_ep *ep_fid, const struct iovec *iov,
 		.opcode = IBV_WR_RDMA_WRITE,
 		.wr.rdma.remote_addr = addr,
 		.wr.rdma.rkey = (uint32_t)key,
-		.qp_type.xrc.remote_srqn = ep->peer_srqn,
+		FI_IBV_SET_REMOTE_SRQN(ep->peer_srqn)
 	};
 
 	return fi_ibv_send_iov(&ep->base_ep, &wr, iov, desc, count);
@@ -323,7 +323,7 @@ fi_ibv_msg_xrc_ep_rma_writemsg(struct fid_ep *ep_fid,
 		.wr_id = (uintptr_t)msg->context,
 		.wr.rdma.remote_addr = msg->rma_iov->addr,
 		.wr.rdma.rkey = (uint32_t)msg->rma_iov->key,
-		.qp_type.xrc.remote_srqn = ep->peer_srqn,
+		FI_IBV_SET_REMOTE_SRQN(ep->peer_srqn)
 	};
 
 	if (flags & FI_REMOTE_CQ_DATA) {
@@ -348,7 +348,7 @@ fi_ibv_msg_xrc_ep_rma_read(struct fid_ep *ep_fid, void *buf, size_t len,
 		.opcode = IBV_WR_RDMA_READ,
 		.wr.rdma.remote_addr = addr,
 		.wr.rdma.rkey = (uint32_t)key,
-		.qp_type.xrc.remote_srqn = ep->peer_srqn,
+		FI_IBV_SET_REMOTE_SRQN(ep->peer_srqn)
 	};
 
 	return fi_ibv_send_buf(&ep->base_ep, &wr, buf, len, desc);
@@ -367,7 +367,7 @@ fi_ibv_msg_xrc_ep_rma_readv(struct fid_ep *ep_fid, const struct iovec *iov,
 		.wr.rdma.remote_addr = addr,
 		.wr.rdma.rkey = (uint32_t)key,
 		.num_sge = count,
-		.qp_type.xrc.remote_srqn = ep->peer_srqn,
+		FI_IBV_SET_REMOTE_SRQN(ep->peer_srqn)
 	};
 
 	fi_ibv_set_sge_iov(wr.sg_list, iov, count, desc);
@@ -388,7 +388,7 @@ fi_ibv_msg_xrc_ep_rma_readmsg(struct fid_ep *ep_fid,
 		.wr.rdma.remote_addr = msg->rma_iov->addr,
 		.wr.rdma.rkey = (uint32_t)msg->rma_iov->key,
 		.num_sge = msg->iov_count,
-		.qp_type.xrc.remote_srqn = ep->peer_srqn,
+		FI_IBV_SET_REMOTE_SRQN(ep->peer_srqn)
 	};
 
 	fi_ibv_set_sge_iov(wr.sg_list, msg->msg_iov, msg->iov_count, msg->desc);
@@ -410,7 +410,7 @@ fi_ibv_msg_xrc_ep_rma_writedata(struct fid_ep *ep_fid, const void *buf,
 		.wr.rdma.remote_addr = addr,
 		.wr.rdma.rkey = (uint32_t)key,
 		.send_flags = VERBS_INJECT(&ep->base_ep, len),
-		.qp_type.xrc.remote_srqn = ep->peer_srqn,
+		FI_IBV_SET_REMOTE_SRQN(ep->peer_srqn)
 	};
 
 	return fi_ibv_send_buf(&ep->base_ep, &wr, buf, len, desc);
@@ -429,7 +429,7 @@ fi_ibv_msg_xrc_ep_rma_inject_write(struct fid_ep *ep_fid, const void *buf,
 		.wr.rdma.remote_addr = addr,
 		.wr.rdma.rkey = (uint32_t)key,
 		.send_flags = IBV_SEND_INLINE,
-		.qp_type.xrc.remote_srqn = ep->peer_srqn,
+		FI_IBV_SET_REMOTE_SRQN(ep->peer_srqn)
 	};
 
 	return fi_ibv_send_buf_inline(&ep->base_ep, &wr, buf, len);
@@ -444,7 +444,9 @@ fi_ibv_xrc_rma_write_fast(struct fid_ep *ep_fid, const void *buf,
 
 	ep->base_ep.wrs->rma_wr.wr.rdma.remote_addr = addr;
 	ep->base_ep.wrs->rma_wr.wr.rdma.rkey = (uint32_t) key;
+#if VERBS_HAVE_XRC
 	ep->base_ep.wrs->rma_wr.qp_type.xrc.remote_srqn = ep->peer_srqn;
+#endif
 	ep->base_ep.wrs->sge.addr = (uintptr_t) buf;
 	ep->base_ep.wrs->sge.length = (uint32_t) len;
 
@@ -467,7 +469,7 @@ fi_ibv_msg_xrc_ep_rma_inject_writedata(struct fid_ep *ep_fid,
 		.wr.rdma.remote_addr = addr,
 		.wr.rdma.rkey = (uint32_t)key,
 		.send_flags = IBV_SEND_INLINE,
-		.qp_type.xrc.remote_srqn = ep->peer_srqn,
+		FI_IBV_SET_REMOTE_SRQN(ep->peer_srqn)
 	};
 
 	return fi_ibv_send_buf_inline(&ep->base_ep, &wr, buf, len);
@@ -483,7 +485,9 @@ fi_ibv_msg_xrc_ep_rma_inject_writedata_fast(struct fid_ep *ep_fid,
 						base_ep.util_ep.ep_fid);
 	ep->base_ep.wrs->rma_wr.wr.rdma.remote_addr = addr;
 	ep->base_ep.wrs->rma_wr.wr.rdma.rkey = (uint32_t) key;
+#if VERBS_HAVE_XRC
 	ep->base_ep.wrs->rma_wr.qp_type.xrc.remote_srqn = ep->peer_srqn;
+#endif
 	ep->base_ep.wrs->rma_wr.imm_data = htonl((uint32_t) data);
 	ep->base_ep.wrs->rma_wr.opcode = IBV_WR_RDMA_WRITE_WITH_IMM;
 


### PR DESCRIPTION
RHEL runs an old version of libibverbs that isn't supported
with the current version of the verbs provider. This commit
introduces several defines and macros to simulate the existence
of an updated libibverbs and header files and relies on the
underlying libraries to provide the appropriate errors when
necessary.

Signed-off-by: James Swaro <jswaro@cray.com>