### PR TITLE
contrib/cray: Change publish criteria

### DIFF
--- a/contrib/cray/Jenkinsfile.verbs
+++ b/contrib/cray/Jenkinsfile.verbs
@@ -365,7 +365,7 @@ pipeline {
             when {
                 allOf {
                     expression { currentBuild.result == 'SUCCESS' } ;
-                    expression { env.BRANCH_NAME == 'master' }
+                    expression { return isRelease("${env.GIT_BRANCH}") }
                 }
             }
             steps {


### PR DESCRIPTION
This commit introduces the isRelease function to the set of
criteria checked during the publish stage. If the branch name provided
is the same branch that should be published to the DST repository,
then the expression should trigger the publish stage.

Signed-off-by: James Swaro <jswaro@cray.com>