### PR TITLE
Fix segfault(s)/asserts in XRC handling of CM REJ messages

### DIFF
--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -244,8 +244,10 @@ static void fi_ibv_eq_skip_xrc_cm_data(const void **priv_data,
 {
 	const struct fi_ibv_xrc_cm_data *cm_data = *priv_data;
 
-	*priv_data = (cm_data + 1);
-	*priv_data_len -= sizeof(*cm_data);
+	if (*priv_data_len > sizeof(*cm_data)) {
+		*priv_data = (cm_data + 1);
+		*priv_data_len -= sizeof(*cm_data);
+	}
 }
 
 static int

--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -459,7 +459,11 @@ fi_ibv_eq_xrc_connected_event(struct fi_ibv_eq *eq,
 	 * ID(s) since  RDMA CM is used for connection setup only */
 	*acked = 1;
 	rdma_ack_cm_event(cma_event);
-	fi_ibv_free_xrc_conn_setup(ep);
+
+	/* TODO: Ultimately we will want to initiate freeing of the connection
+	 * resources here with fi_ibv_free_xrc_conn_setup(ep); however, timewait
+	 * issues in larger fabrics need to be resolved first. The resources
+	 * will be freed at EP close if not freed here */
 
 	return ret;
 }


### PR DESCRIPTION
This PR fixes two XRC CM REJ message handling bugs associated with CM REJ messages that are initiated from the CM, not the peer provider (two commits). It also temporarily disables the early release of XRC connection resources and lets the existing EP close normal processing handle it (one commit). The latter is to allow correct operation until resources remaining in timed wait state can be handled.