### PR TITLE
prov/rxm: Fix setting of FI_MSG and FI_RMA caps for core hints

### DIFF
--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -91,11 +91,11 @@ int rxm_info_to_core(uint32_t version, const struct fi_info *hints,
 	core_info->mode |= FI_RX_CQ_DATA | FI_CONTEXT;
 
 	if (hints) {
-		if (hints->caps & FI_TAGGED)
+		if (hints->caps & (FI_MSG | FI_ATOMIC | FI_TAGGED))
 			core_info->caps |= FI_MSG;
 
 		/* FI_RMA cap is needed for large message transfer protocol */
-		if (hints->caps & (FI_MSG | FI_TAGGED))
+		if (hints->caps & (FI_RMA | FI_MSG | FI_ATOMIC | FI_TAGGED))
 			core_info->caps |= FI_RMA;
 
 		if (hints->domain_attr) {


### PR DESCRIPTION
Make sure FI_MSG and FI_RMA caps are set correctly in the core provider
hints, taking into account FI_ATOMIC needs FI_MSG, and that FI_RMA and
FI_MSG may not both be set in info passed to an RXM EP.

Signed-off-by: Steve Welch <swelch@systemfabricworks.com>