### PR TITLE
prov/rxm: Fix initialization of maximum atomic payload size

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -731,6 +731,16 @@ int rxm_ep_prepost_buf(struct rxm_ep *rxm_ep, struct fid_ep *msg_ep);
 int rxm_ep_query_atomic(struct fid_domain *domain, enum fi_datatype datatype,
 			enum fi_op op, struct fi_atomic_attr *attr,
 			uint64_t flags);
+static inline size_t rxm_ep_max_atomic_size(struct fi_info *info)
+{
+	size_t overhead = sizeof(struct rxm_atomic_hdr) +
+			  sizeof(struct rxm_pkt);
+
+	/* Must be set to eager size or less */
+	return (info->tx_attr && info->tx_attr->inject_size > overhead) ?
+		info->tx_attr->inject_size - overhead : 0;
+}
+
 static inline ssize_t
 rxm_atomic_send_respmsg(struct rxm_ep *rxm_ep, struct rxm_conn *conn,
 			struct rxm_tx_atomic_buf *resp_buf, ssize_t len)

--- a/prov/rxm/src/rxm_domain.c
+++ b/prov/rxm/src/rxm_domain.c
@@ -338,10 +338,7 @@ int rxm_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	 * since we specify the key used by MSG_EP provider. */
 	rxm_domain->util_domain.mr_map.mode &= ~FI_MR_PROV_KEY;
 
-	/* Must be set to eager size or less */
-	rxm_domain->max_atomic_size = info->tx_attr ?
-				      info->tx_attr->inject_size : 0;
-
+	rxm_domain->max_atomic_size = rxm_ep_max_atomic_size(info);
 	*domain = &rxm_domain->util_domain.domain_fid;
 	(*domain)->fid.ops = &rxm_domain_fi_ops;
 	/* Replace MR ops set by ofi_domain_init() */


### PR DESCRIPTION
When returning the maximum atomic payload size reserve space for protocol headers.

Signed-off-by: Steve Welch <swelch@systemfabricworks.com>