### PR TITLE
prov/verbs: Make verbs fi_getinfo rx_attr verification thread-safe

### DIFF
--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -199,19 +199,22 @@ int fi_ibv_check_rx_attr(const struct fi_rx_attr *attr,
 			 const struct fi_info *hints,
 			 const struct fi_info *info)
 {
-	/* WARNING: This is not thread safe */
-	uint64_t saved_prov_mode = info->rx_attr->mode;
+	struct fi_info *dup_info;
 	int ret;
 
-	info->rx_attr->mode = (hints->domain_attr &&
-			       hints->domain_attr->cq_data_size) ?
-			info->rx_attr->mode :
-			(info->rx_attr->mode & ~FI_RX_CQ_DATA);
+	if (hints->mode & FI_RX_CQ_DATA || (hints->rx_attr &&
+	    (hints->rx_attr->mode & FI_RX_CQ_DATA))) {
+		ret = ofi_check_rx_attr(&fi_ibv_prov, info, attr, hints->mode);
+	} else {
+		dup_info = fi_dupinfo(info);
+		if (!dup_info)
+			return -FI_ENOMEM;
 
-	ret = ofi_check_rx_attr(&fi_ibv_prov, info, attr, hints->mode);
-
-	info->rx_attr->mode = saved_prov_mode;
-
+		dup_info->rx_attr->mode &= ~FI_RX_CQ_DATA;
+		ret = ofi_check_rx_attr(&fi_ibv_prov, dup_info, attr,
+					hints->mode);
+		fi_freeinfo(dup_info);
+	}
 	return ret;
 }
 


### PR DESCRIPTION
Handle the case where the application has not requested FI_RX_CQ_DATA
in the RX attribute check by removing FI_RX_CQ_DATA in a copy of the
default fi_info. Note, that this fix also removes the check of
domain->cq_data_size as a method of determining if FI_RX_CQ_DATA is
required. It is an error to set domain->cq_data_size and not also
include FI_RX_CQ_DATA.

Signed-off-by: Steve Welch <swelch@systemfabricworks.com>