### PR TITLE
prov/rxm: Fix returned fi_info attributes when FI_ATOMIC is specified

### DIFF
--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -223,6 +223,9 @@ static void rxm_alter_info(const struct fi_info *hints, struct fi_info *info)
 					~(RXM_ATOMIC_UNSUPPORTED_MSG_ORDER);
 				cur->rx_attr->msg_order &=
 					~(RXM_ATOMIC_UNSUPPORTED_MSG_ORDER);
+				cur->ep_attr->max_order_raw_size = 0;
+				cur->ep_attr->max_order_war_size = 0;
+				cur->ep_attr->max_order_waw_size = 0;
 			} else {
 				cur->caps &= ~FI_ATOMIC;
 				cur->tx_attr->caps &= ~FI_ATOMIC;
@@ -259,6 +262,12 @@ static int rxm_validate_atomic_hints(const struct fi_info *hints)
 	if (!hints || !(hints->caps & FI_ATOMIC))
 		return 0;
 
+	if (hints->domain_attr &&
+	    hints->domain_attr->data_progress == FI_PROGRESS_AUTO) {
+		FI_DBG(&rxm_prov, FI_LOG_FABRIC,
+		       "FI_ATOMIC does not support data FI_PROGRESS_AUTO\n");
+		return -FI_EINVAL;
+	}
 	if (hints->tx_attr && (hints->tx_attr->msg_order &
 			       RXM_ATOMIC_UNSUPPORTED_MSG_ORDER)) {
 		FI_DBG(&rxm_prov, FI_LOG_FABRIC,


### PR DESCRIPTION
Clear EP max order size for unsupported message order and force
data FI_MANUAL_PROGRESS until auto data progress can be supported.

Signed-off-by: Steve Welch <swelch@systemfabricworks.com>