### PR TITLE
prov/verbs: Release XRC shared connection setup resources once connected

### DIFF
--- a/prov/verbs/src/verbs_domain_xrc.c
+++ b/prov/verbs/src/verbs_domain_xrc.c
@@ -179,6 +179,8 @@ void fi_ibv_put_shared_ini_conn(struct fi_ibv_xrc_ep *ep)
 	ini_conn = ep->ini_conn;
 	ep->ini_conn = NULL;
 	ep->base_ep.ibv_qp = NULL;
+	if (ep->base_ep.id)
+		ep->base_ep.id->qp = NULL;
 	ep->base_ep.id->qp = NULL;
 
 	/* Tear down physical INI/TGT when no longer being used */
@@ -410,6 +412,8 @@ static int fi_ibv_put_tgt_qp(struct fi_ibv_xrc_ep *ep)
 		return -errno;
 	}
 	ep->tgt_ibv_qp = NULL;
+	if (ep->tgt_id)
+		ep->tgt_id->qp = NULL;
 
 	return FI_SUCCESS;
 }

--- a/prov/verbs/src/verbs_ep.c
+++ b/prov/verbs/src/verbs_ep.c
@@ -226,9 +226,9 @@ static inline void fi_ibv_ep_xrc_close(struct fi_ibv_ep *ep)
 	struct fi_ibv_xrc_ep *xrc_ep = container_of(ep, struct fi_ibv_xrc_ep,
 						    base_ep);
 
-	fi_ibv_ep_destroy_xrc_qp(xrc_ep);
 	if (xrc_ep->conn_setup)
 		fi_ibv_free_xrc_conn_setup(xrc_ep);
+	fi_ibv_ep_destroy_xrc_qp(xrc_ep);
 }
 
 static int fi_ibv_ep_close(fid_t fid)

--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -454,15 +454,12 @@ fi_ibv_eq_xrc_connected_event(struct fi_ibv_eq *eq,
 
 	ret = fi_ibv_eq_xrc_recip_conn_event(eq, ep, cma_event, entry, len);
 
-	/* Bidirectional connection setup is complete, destroy RDMA CM
-	 * ID(s) since  RDMA CM is used for connection setup only */
+	/* Bidirectional connection setup is complete, disconnect RDMA CM
+	 * ID(s) and release shared QP reservations/hardware resources
+	 * that were needed for shared connection setup only. */
 	*acked = 1;
 	rdma_ack_cm_event(cma_event);
-
-	/* TODO: Ultimately we will want to initiate freeing of the connection
-	 * resources here with fi_ibv_free_xrc_conn_setup(ep); however, timewait
-	 * issues in larger fabrics need to be resolved first. The resources
-	 * will be freed at EP close if not freed here */
+	fi_ibv_free_xrc_conn_setup(ep);
 
 	return ret;
 }


### PR DESCRIPTION
Enable releasing of the H/W resources used to reserve unique QP numbers
during RDMA CM connection setup of XRC shared connections. Since the
RDMA CM is used for connection setup only, the associated RDMA CM ids
are disconnected and the QP that were reserved in the INIT state are
destroyed.

Signed-off-by: Steve Welch <swelch@systemfabricworks.com>