### PR TITLE
prov/verbs: Add XRC support for inject_fast/injectdata_fast

### DIFF
--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -662,6 +662,7 @@ const struct fi_ops_msg fi_ibv_dgram_msg_ops;
 const struct fi_ops_msg fi_ibv_msg_xrc_ep_msg_ops;
 const struct fi_ops_msg fi_ibv_msg_xrc_ep_msg_ops_ts;
 const struct fi_ops_msg fi_ibv_msg_srq_xrc_ep_msg_ops;
+const struct fi_ops_msg fi_ibv_msg_srq_xrc_ep_msg_ops_ts;
 struct fi_ops_rma fi_ibv_msg_ep_rma_ops_ts;
 struct fi_ops_rma fi_ibv_msg_ep_rma_ops;
 struct fi_ops_rma fi_ibv_msg_xrc_ep_rma_ops_ts;

--- a/prov/verbs/src/verbs_ep.c
+++ b/prov/verbs/src/verbs_ep.c
@@ -631,7 +631,11 @@ static int fi_ibv_ep_enable(struct fid_ep *ep_fid)
 			/* Override receive function pointers to prevent the user from
 			 * posting Receive WRs to a QP where a SRQ is attached to it */
 			if (domain->use_xrc) {
-				*ep->util_ep.ep_fid.msg = fi_ibv_msg_srq_xrc_ep_msg_ops;
+				if (domain->util_domain.threading == FI_THREAD_SAFE)
+					*ep->util_ep.ep_fid.msg = fi_ibv_msg_srq_xrc_ep_msg_ops_ts;
+				else
+					*ep->util_ep.ep_fid.msg = fi_ibv_msg_srq_xrc_ep_msg_ops;
+
 				return fi_ibv_ep_enable_xrc(ep);
 			} else {
 				ep->util_ep.ep_fid.msg->recv = fi_no_msg_recv;


### PR DESCRIPTION
Add MSG support for polling the CQ if needed on inject when threading model supports it. This mirrors what is done for RC.

Signed-off-by: Steve Welch <swelch@systemfabricworks.com>