### PR TITLE
contrib/cray: Use environment provided fabtests

### DIFF
--- a/contrib/cray/bin/fabtest_wrapper.sh
+++ b/contrib/cray/bin/fabtest_wrapper.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
-export FABTESTS_PATH=/scratch/jenkins/builds/fabtests/stable
-export PATH=${FABTESTS_PATH}/bin:$PATH
+if [[ -z ${FABTEST_PATH} ]] ; then
+	export FABTEST_PATH=/scratch/jenkins/builds/fabtests/stable
+fi
+
+export PATH=${FABTEST_PATH}/bin:$PATH
 
 if [[ -z ${FABTEST_PROVIDER} ]] ; then
     FABTEST_PROVIDER='verbs;ofi_rxm'


### PR DESCRIPTION
If provided in the environment, use the fabtest installation in the environment.
This allows us to select the correct version of fabtests when running functional
tests.

Signed-off-by: James Swaro <jswaro@cray.com>