### PR TITLE
prov/rxm: Check for SRX use when freeing rx buf when msg_ep closed

### DIFF
--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -1384,6 +1384,14 @@ void rxm_ep_do_progress(struct util_ep *util_ep)
 				buf, repost_entry);
 
 		/* Discard rx buffer if its msg_ep was closed */
+		if (!buf->conn) {
+			assert(buf->ep->srx_ctx);
+			buf->conn = rxm_key2conn(buf->ep,
+						 buf->pkt.ctrl_hdr.conn_id);
+			if (OFI_UNLIKELY(!buf->conn))
+				continue;
+		}
+
 		if (!buf->conn->msg_ep) {
 			ofi_buf_free(&buf->hdr);
 			continue;


### PR DESCRIPTION
Add check to fix SRX use with OFIWG PR5123 fixes.

Signed-off-by: Steve Welch <swelch@systemfabricworks.com>