### PR TITLE
prov/verbs: Remove possible deadlock in XRC error path logic

### DIFF
--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -753,6 +753,8 @@ static inline int fi_ibv_cmp_xrc_domain_name(const char *domain_name,
 
 int fi_ibv_cq_signal(struct fid_cq *cq);
 
+ssize_t _fi_ibv_eq_write_event(struct fi_ibv_eq *eq, uint32_t event,
+		const void *buf, size_t len);
 ssize_t fi_ibv_eq_write_event(struct fi_ibv_eq *eq, uint32_t event,
 		const void *buf, size_t len);
 

--- a/prov/verbs/src/verbs_domain_xrc.c
+++ b/prov/verbs/src/verbs_domain_xrc.c
@@ -231,8 +231,8 @@ static void fi_ibv_create_shutdown_event(struct fi_ibv_xrc_ep *ep)
 		.fid = &ep->base_ep.util_ep.ep_fid.fid,
 	};
 
-	fi_ibv_eq_write_event(ep->base_ep.eq, FI_SHUTDOWN,
-			      &entry, sizeof(entry));
+	_fi_ibv_eq_write_event(ep->base_ep.eq, FI_SHUTDOWN,
+			       &entry, sizeof(entry));
 }
 
 /* Caller must hold domain:eq:lock */


### PR DESCRIPTION
Add the capability to write an EQ entry while
already holding the EQ lock. This has not been seen in
practice, but could occur if an asynchronous call into
rdma_route_resolv() returned an error.

Signed-off-by: Steve Welch <swelch@systemfabricworks.com>