### PR TITLE
prov/verbs: Use RDMA CM SIDR message exchanges for shared XRC QP

### DIFF
--- a/include/ofi_coll.h
+++ b/include/ofi_coll.h
@@ -122,6 +122,7 @@ struct util_coll_mc {
 };
 
 struct join_data {
+	struct util_coll_mc *new_mc;
 	struct bitmask data;
 	struct bitmask tmp;
 };

--- a/include/rdma/fi_collective.h
+++ b/include/rdma/fi_collective.h
@@ -46,22 +46,6 @@ extern "C" {
 #include <rdma/fi_direct_collective_def.h>
 #endif /* FABRIC_DIRECT */
 
-#ifndef FABRIC_DIRECT_COLLECTIVE_DEF
-
-enum fi_collective_op {
-	FI_BARRIER,
-	FI_BROADCAST,
-	FI_ALLTOALL,
-	FI_ALLREDUCE,
-	FI_ALLGATHER,
-	FI_REDUCE_SCATTER,
-	FI_REDUCE,
-	FI_SCATTER,
-	FI_GATHER,
-};
-
-#endif
-
 
 struct fi_ops_av_set {
 	size_t	size;

--- a/include/rdma/fi_domain.h
+++ b/include/rdma/fi_domain.h
@@ -198,12 +198,27 @@ enum fi_op {
 
 #endif
 
+#ifndef FABRIC_DIRECT_COLLECTIVE_DEF
+
+enum fi_collective_op {
+	FI_BARRIER,
+	FI_BROADCAST,
+	FI_ALLTOALL,
+	FI_ALLREDUCE,
+	FI_ALLGATHER,
+	FI_REDUCE_SCATTER,
+	FI_REDUCE,
+	FI_SCATTER,
+	FI_GATHER,
+};
+
+#endif
+
 
 struct fi_atomic_attr;
 struct fi_cq_attr;
 struct fi_cntr_attr;
 struct fi_collective_attr;
-enum   fi_collective_op;
 
 struct fi_ops_domain {
 	size_t	size;

--- a/prov/util/src/util_cntr.c
+++ b/prov/util/src/util_cntr.c
@@ -193,6 +193,17 @@ static struct fi_ops_cntr util_cntr_ops = {
 	.wait = ofi_cntr_wait
 };
 
+static struct fi_ops_cntr util_cntr_no_wait_ops = {
+	.size = sizeof(struct fi_ops_cntr),
+	.read = ofi_cntr_read,
+	.readerr = ofi_cntr_readerr,
+	.add = ofi_cntr_add,
+	.adderr = ofi_cntr_adderr,
+	.set = ofi_cntr_set,
+	.seterr = ofi_cntr_seterr,
+	.wait = fi_no_cntr_wait,
+};
+
 int ofi_cntr_cleanup(struct util_cntr *cntr)
 {
 	if (ofi_atomic_get32(&cntr->ref))
@@ -220,54 +231,6 @@ static int util_cntr_close(struct fid *fid)
 	if (ret)
 		return ret;
 	free(cntr);
-	return 0;
-}
-
-static int fi_cntr_init(struct fid_domain *domain, struct fi_cntr_attr *attr,
-			struct util_cntr *cntr, void *context)
-{
-	struct fi_wait_attr wait_attr;
-	struct fid_wait *wait;
-	int ret;
-
-	cntr->domain = container_of(domain, struct util_domain, domain_fid);
-	ofi_atomic_initialize32(&cntr->ref, 0);
-	ofi_atomic_initialize64(&cntr->cnt, 0);
-	ofi_atomic_initialize64(&cntr->err, 0);
-	dlist_init(&cntr->ep_list);
-	fastlock_init(&cntr->ep_list_lock);
-
-	cntr->cntr_fid.fid.fclass = FI_CLASS_CNTR;
-	cntr->cntr_fid.fid.context = context;
-
-	switch (attr->wait_obj) {
-	case FI_WAIT_NONE:
-		wait = NULL;
-		cntr->cntr_fid.ops->wait = fi_no_cntr_wait;
-		break;
-	case FI_WAIT_UNSPEC:
-	case FI_WAIT_FD:
-	case FI_WAIT_MUTEX_COND:
-		memset(&wait_attr, 0, sizeof wait_attr);
-		wait_attr.wait_obj = attr->wait_obj;
-		cntr->internal_wait = 1;
-		ret = fi_wait_open(&cntr->domain->fabric->fabric_fid,
-				   &wait_attr, &wait);
-		if (ret)
-			return ret;
-		break;
-	case FI_WAIT_SET:
-		wait = attr->wait_set;
-		break;
-	default:
-		assert(0);
-		return -FI_EINVAL;
-	}
-
-	if (wait)
-		cntr->wait = container_of(wait, struct util_wait, wait_fid);
-
-	ofi_atomic_inc32(&cntr->domain->ref);
 	return 0;
 }
 
@@ -299,22 +262,56 @@ int ofi_cntr_init(const struct fi_provider *prov, struct fid_domain *domain,
 		  ofi_cntr_progress_func progress, void *context)
 {
 	int ret;
+	struct fi_wait_attr wait_attr;
+	struct fid_wait *wait;
 
 	assert(progress);
 	ret = ofi_check_cntr_attr(prov, attr);
 	if (ret)
 		return ret;
 
+	cntr->progress = progress;
+	cntr->domain = container_of(domain, struct util_domain, domain_fid);
+	ofi_atomic_initialize32(&cntr->ref, 0);
+	ofi_atomic_initialize64(&cntr->cnt, 0);
+	ofi_atomic_initialize64(&cntr->err, 0);
+	dlist_init(&cntr->ep_list);
+
+	cntr->cntr_fid.fid.fclass = FI_CLASS_CNTR;
+	cntr->cntr_fid.fid.context = context;
 	cntr->cntr_fid.fid.ops = &util_cntr_fi_ops;
 	cntr->cntr_fid.ops = &util_cntr_ops;
-	cntr->progress = progress;
 
-	ret = fi_cntr_init(domain, attr, cntr, context);
-	if (ret)
-		return ret;
+	switch (attr->wait_obj) {
+	case FI_WAIT_NONE:
+		wait = NULL;
+		cntr->cntr_fid.ops = &util_cntr_no_wait_ops;
+		break;
+	case FI_WAIT_UNSPEC:
+	case FI_WAIT_FD:
+	case FI_WAIT_MUTEX_COND:
+		memset(&wait_attr, 0, sizeof wait_attr);
+		wait_attr.wait_obj = attr->wait_obj;
+		cntr->internal_wait = 1;
+		ret = fi_wait_open(&cntr->domain->fabric->fabric_fid,
+				   &wait_attr, &wait);
+		if (ret)
+			return ret;
+		break;
+	case FI_WAIT_SET:
+		wait = attr->wait_set;
+		break;
+	default:
+		assert(0);
+		return -FI_EINVAL;
+	}
+
+	fastlock_init(&cntr->ep_list_lock);
+	ofi_atomic_inc32(&cntr->domain->ref);
 
 	/* CNTR must be fully operational before adding to wait set */
-	if (cntr->wait) {
+	if (wait) {
+		cntr->wait = container_of(wait, struct util_wait, wait_fid);
 		ret = fi_poll_add(&cntr->wait->pollset->poll_fid,
 				  &cntr->cntr_fid.fid, 0);
 		if (ret) {

--- a/prov/util/src/util_coll.c
+++ b/prov/util/src/util_coll.c
@@ -555,10 +555,10 @@ void util_coll_join_comp(struct util_coll_operation *coll_op)
 	struct fi_eq_err_entry entry;
 	struct util_ep *ep = container_of(coll_op->mc->ep, struct util_ep, ep_fid);
 
-	coll_op->mc->seq = 0;
-	coll_op->mc->group_id = ofi_bitmask_get_lsbset(coll_op->data.join.data);
+	coll_op->data.join.new_mc->seq = 0;
+	coll_op->data.join.new_mc->group_id = ofi_bitmask_get_lsbset(coll_op->data.join.data);
 	// mark the local mask bit
-	ofi_bitmask_unset(ep->coll_cid_mask, coll_op->mc->group_id);
+	ofi_bitmask_unset(ep->coll_cid_mask, coll_op->data.join.new_mc->group_id);
 
 	/* write to the eq  */
 	memset(&entry, 0, sizeof(entry));
@@ -740,6 +740,8 @@ int ofi_join_collective(struct fid_ep *ep, fi_addr_t coll_addr,
 				util_coll_join_comp);
 	if (ret)
 		goto err1;
+
+	join_op->data.join.new_mc = new_coll_mc;
 
 	if (new_coll_mc->local_rank != FI_ADDR_NOTAVAIL) {
 		ret = ofi_bitmask_create(&join_op->data.join.data, OFI_MAX_GROUP_ID);

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -206,7 +206,8 @@ err1:
 	return ret;
 }
 
-int fi_ibv_create_ep(const struct fi_info *hints, struct rdma_cm_id **id)
+int fi_ibv_create_ep(const struct fi_info *hints, enum rdma_port_space ps,
+		     struct rdma_cm_id **id)
 {
 	struct rdma_addrinfo *rai = NULL;
 	int ret;
@@ -216,7 +217,7 @@ int fi_ibv_create_ep(const struct fi_info *hints, struct rdma_cm_id **id)
 		return ret;
 	}
 
-	if (rdma_create_id(NULL, id, NULL, RDMA_PS_TCP)) {
+	if (rdma_create_id(NULL, id, NULL, ps)) {
 		ret = -errno;
 		FI_WARN(&fi_ibv_prov, FI_LOG_FABRIC, "rdma_create_id failed: "
 			"%s (%d)\n", strerror(-ret), -ret);

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -303,6 +303,12 @@ struct fi_ibv_pep {
 	struct fid_pep		pep_fid;
 	struct fi_ibv_eq	*eq;
 	struct rdma_cm_id	*id;
+
+	/* XRC uses SIDR based RDMA CM exchanges for setting up
+	 * shared QP connections. This ID is bound to the same
+	 * port number as "id", but the RDMA_PS_UDP port space. */
+	struct rdma_cm_id	*xrc_ps_udp_id;
+
 	int			backlog;
 	int			bound;
 	size_t			src_addrlen;

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -613,7 +613,8 @@ int fi_ibv_open_ep(struct fid_domain *domain, struct fi_info *info,
 		   struct fid_ep **ep, void *context);
 int fi_ibv_passive_ep(struct fid_fabric *fabric, struct fi_info *info,
 		      struct fid_pep **pep, void *context);
-int fi_ibv_create_ep(const struct fi_info *hints, struct rdma_cm_id **id);
+int fi_ibv_create_ep(const struct fi_info *hints, enum rdma_port_space ps,
+		     struct rdma_cm_id **id);
 int fi_ibv_dgram_av_open(struct fid_domain *domain_fid, struct fi_av_attr *attr,
 			 struct fid_av **av_fid, void *context);
 static inline

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -533,7 +533,7 @@ struct fi_ibv_xrc_ep_conn_setup {
 	 * with the original request. The tag is created by the
 	 * original active side. */
 	uint32_t			conn_tag;
-	bool				created_conn_tag;
+	uint32_t			remote_conn_tag;
 
 	/* Temporary flags to indicate if the INI QP setup and the
 	 * TGT QP setup have completed. */

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -535,14 +535,6 @@ struct fi_ibv_xrc_ep_conn_setup {
 	uint32_t			conn_tag;
 	bool				created_conn_tag;
 
-	/* IB CM message stale/duplicate detection processing requires
-	 * that shared INI/TGT connections use unique QP numbers during
-	 * RDMA CM connection setup. To avoid conflicts with actual HCA
-	 * QP number space, we allocate minimal QP that are left in the
-	 * reset state and closed once the setup process completes. */
-	struct ibv_qp			*rsvd_ini_qpn;
-	struct ibv_qp			*rsvd_tgt_qpn;
-
 	/* Temporary flags to indicate if the INI QP setup and the
 	 * TGT QP setup have completed. */
 	bool				ini_connected;

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -535,11 +535,6 @@ struct fi_ibv_xrc_ep_conn_setup {
 	uint32_t			conn_tag;
 	uint32_t			remote_conn_tag;
 
-	/* Temporary flags to indicate if the INI QP setup and the
-	 * TGT QP setup have completed. */
-	bool				ini_connected;
-	bool				tgt_connected;
-
 	/* Delivery of the FI_CONNECTED event is delayed until
 	 * bidirectional connectivity is established. */
 	size_t				event_len;

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -588,6 +588,7 @@ struct fi_ibv_xrc_ep {
 	struct rdma_cm_id		*tgt_id;
 	struct ibv_qp			*tgt_ibv_qp;
 	enum fi_ibv_xrc_ep_conn_state	conn_state;
+	bool				recip_req_received;
 	uint32_t			magic;
 	uint32_t			srqn;
 	uint32_t			peer_srqn;

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -634,13 +634,14 @@ struct fi_ops_rma fi_ibv_msg_ep_rma_ops;
 struct fi_ops_rma fi_ibv_msg_xrc_ep_rma_ops_ts;
 struct fi_ops_rma fi_ibv_msg_xrc_ep_rma_ops;
 
-#define FI_IBV_XRC_VERSION	1
+#define FI_IBV_XRC_VERSION	2
 
 struct fi_ibv_xrc_cm_data {
 	uint8_t		version;
 	uint8_t		reciprocal;
 	uint16_t	port;
-	uint32_t	param;
+	uint32_t	tgt_qpn;
+	uint32_t	srqn;
 	uint32_t	conn_tag;
 };
 
@@ -648,7 +649,8 @@ struct fi_ibv_xrc_conn_info {
 	uint32_t		conn_tag;
 	uint32_t		is_reciprocal;
 	uint32_t		ini_qpn;
-	uint32_t		conn_data;
+	uint32_t		tgt_qpn;
+	uint32_t		peer_srqn;
 	uint16_t		port;
 	struct rdma_conn_param	conn_param;
 };
@@ -680,7 +682,8 @@ void fi_ibv_eq_clear_xrc_conn_tag(struct fi_ibv_xrc_ep *ep);
 struct fi_ibv_xrc_ep *fi_ibv_eq_xrc_conn_tag2ep(struct fi_ibv_eq *eq,
 						uint32_t conn_tag);
 void fi_ibv_set_xrc_cm_data(struct fi_ibv_xrc_cm_data *local, int reciprocal,
-			    uint32_t conn_tag, uint16_t port, uint32_t param);
+			    uint32_t conn_tag, uint16_t port, uint32_t tgt_qpn,
+			    uint32_t srqn);
 int fi_ibv_verify_xrc_cm_data(struct fi_ibv_xrc_cm_data *remote,
 			      int private_data_len);
 int fi_ibv_connect_xrc(struct fi_ibv_xrc_ep *ep, struct sockaddr *addr,
@@ -700,8 +703,7 @@ void fi_ibv_save_priv_data(struct fi_ibv_xrc_ep *ep, const void *data,
 			   size_t len);
 int fi_ibv_ep_create_ini_qp(struct fi_ibv_xrc_ep *ep, void *dst_addr,
 			    uint32_t *peer_tgt_qpn);
-void fi_ibv_ep_ini_conn_done(struct fi_ibv_xrc_ep *ep, uint32_t peer_srqn,
-			    uint32_t peer_tgt_qpn);
+void fi_ibv_ep_ini_conn_done(struct fi_ibv_xrc_ep *ep, uint32_t peer_tgt_qpn);
 void fi_ibv_ep_ini_conn_rejected(struct fi_ibv_xrc_ep *ep);
 int fi_ibv_ep_create_tgt_qp(struct fi_ibv_xrc_ep *ep, uint32_t tgt_qpn);
 void fi_ibv_ep_tgt_conn_done(struct fi_ibv_xrc_ep *qp);

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -118,6 +118,7 @@
 				 sizeof(struct fi_ibv_cm_data_hdr))
 
 #define FI_IBV_CM_REJ_CONSUMER_DEFINED	28
+#define FI_IBV_CM_REJ_SIDR_CONSUMER_DEFINED	2
 
 #define VERBS_DGRAM_MSG_PREFIX_SIZE	(40)
 

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -753,6 +753,8 @@ static inline int fi_ibv_cmp_xrc_domain_name(const char *domain_name,
 
 int fi_ibv_cq_signal(struct fid_cq *cq);
 
+struct fi_ibv_eq_entry *fi_ibv_eq_alloc_entry(uint32_t event,
+					      const void *buf, size_t len);
 ssize_t fi_ibv_eq_write_event(struct fi_ibv_eq *eq, uint32_t event,
 		const void *buf, size_t len);
 

--- a/prov/verbs/src/verbs_cm.c
+++ b/prov/verbs/src/verbs_cm.c
@@ -374,10 +374,9 @@ fi_ibv_msg_xrc_ep_connect(struct fid_ep *ep, const void *addr,
 		free(cm_hdr);
 		return -FI_ENOMEM;
 	}
+	xrc_ep->conn_setup->conn_tag = VERBS_CONN_TAG_INVALID;
 
 	fastlock_acquire(&xrc_ep->base_ep.eq->lock);
-	xrc_ep->conn_setup->conn_tag = VERBS_CONN_TAG_INVALID;
-	fi_ibv_eq_set_xrc_conn_tag(xrc_ep);
 	ret = fi_ibv_connect_xrc(xrc_ep, NULL, 0, adjusted_param, paramlen);
 	fastlock_release(&xrc_ep->base_ep.eq->lock);
 

--- a/prov/verbs/src/verbs_cm.c
+++ b/prov/verbs/src/verbs_cm.c
@@ -254,7 +254,7 @@ fi_ibv_msg_xrc_ep_reject(struct fi_ibv_connreq *connreq,
 		return ret;
 
 	fi_ibv_set_xrc_cm_data(cm_data, connreq->xrc.is_reciprocal,
-			       connreq->xrc.conn_tag, connreq->xrc.port, 0);
+			       connreq->xrc.conn_tag, connreq->xrc.port, 0, 0);
 	ret = rdma_reject(connreq->id, cm_data,
 			  (uint8_t) paramlen) ? -errno : 0;
 	free(cm_data);

--- a/prov/verbs/src/verbs_cm.c
+++ b/prov/verbs/src/verbs_cm.c
@@ -78,7 +78,7 @@ static int fi_ibv_msg_ep_setname(fid_t ep_fid, void *addr, size_t addrlen)
 
 	memcpy(ep->info->src_addr, addr, ep->info->src_addrlen);
 
-	ret = fi_ibv_create_ep(ep->info, &id);
+	ret = fi_ibv_create_ep(ep->info, RDMA_PS_TCP, &id);
 	if (ret)
 		goto err2;
 

--- a/prov/verbs/src/verbs_cm.c
+++ b/prov/verbs/src/verbs_cm.c
@@ -341,7 +341,6 @@ static int
 fi_ibv_msg_xrc_ep_connect(struct fid_ep *ep, const void *addr,
 		   const void *param, size_t paramlen)
 {
-	struct sockaddr *dst_addr;
 	void *adjusted_param;
 	struct fi_ibv_ep *_ep = container_of(ep, struct fi_ibv_ep,
 					     util_ep.ep_fid);
@@ -379,8 +378,7 @@ fi_ibv_msg_xrc_ep_connect(struct fid_ep *ep, const void *addr,
 	fastlock_acquire(&xrc_ep->base_ep.eq->lock);
 	xrc_ep->conn_setup->conn_tag = VERBS_CONN_TAG_INVALID;
 	fi_ibv_eq_set_xrc_conn_tag(xrc_ep);
-	dst_addr = rdma_get_peer_addr(_ep->id);
-	ret = fi_ibv_connect_xrc(xrc_ep, dst_addr, 0, adjusted_param, paramlen);
+	ret = fi_ibv_connect_xrc(xrc_ep, NULL, 0, adjusted_param, paramlen);
 	fastlock_release(&xrc_ep->base_ep.eq->lock);
 
 	free(adjusted_param);

--- a/prov/verbs/src/verbs_cm_xrc.c
+++ b/prov/verbs/src/verbs_cm_xrc.c
@@ -333,17 +333,17 @@ int fi_ibv_accept_xrc(struct fi_ibv_xrc_ep *ep, int reciprocal,
 
 	/* The passive side of the initial shared connection using
 	 * SIDR is complete, initiate reciprocal connection */
-	if (ep->tgt_id->ps == RDMA_PS_UDP &&
-	    ep->conn_state == FI_IBV_XRC_ORIG_CONNECTING) {
+	if (ep->tgt_id->ps == RDMA_PS_UDP && !reciprocal) {
 		fi_ibv_next_xrc_conn_state(ep);
 		fi_ibv_ep_tgt_conn_done(ep);
 		ret = fi_ibv_connect_xrc(ep, NULL, FI_IBV_RECIP_CONN,
 					 &connect_cm_data,
 					 sizeof(connect_cm_data));
 		if (ret) {
+			VERBS_WARN(FI_LOG_EP_CTRL,
+				   "XRC reciprocal connect error %d\n", ret);
 			fi_ibv_prev_xrc_conn_state(ep);
 			ep->tgt_id->qp = NULL;
-			rdma_disconnect(ep->tgt_id);
 		}
 	}
 

--- a/prov/verbs/src/verbs_cm_xrc.c
+++ b/prov/verbs/src/verbs_cm_xrc.c
@@ -180,14 +180,11 @@ void fi_ibv_free_xrc_conn_setup(struct fi_ibv_xrc_ep *ep, int disconnect)
 		assert(ep->tgt_id);
 		assert(!ep->tgt_id->qp);
 
-		if (ep->conn_setup->tgt_connected) {
-			if (ep->tgt_id->ps == RDMA_PS_UDP) {
-				rdma_destroy_id(ep->tgt_id);
-				ep->tgt_id = NULL;
-			} else {
-				rdma_disconnect(ep->tgt_id);
-			}
-			ep->conn_setup->tgt_connected = 0;
+		if (ep->tgt_id->ps == RDMA_PS_UDP) {
+			rdma_destroy_id(ep->tgt_id);
+			ep->tgt_id = NULL;
+		} else {
+			rdma_disconnect(ep->tgt_id);
 		}
 
 		if (ep->base_ep.id->ps == RDMA_PS_UDP) {
@@ -251,7 +248,6 @@ void fi_ibv_ep_ini_conn_done(struct fi_ibv_xrc_ep *ep, uint32_t tgt_qpn)
 			  ep->ini_conn->tgt_qpn);
 	}
 
-	ep->conn_setup->ini_connected = 1;
 	fi_ibv_log_ep_conn(ep, "INI Connection Done");
 	fi_ibv_sched_ini_conn(ep->ini_conn);
 }
@@ -274,7 +270,6 @@ void fi_ibv_ep_tgt_conn_done(struct fi_ibv_xrc_ep *ep)
 		assert(ep->tgt_ibv_qp == ep->tgt_id->qp);
 		ep->tgt_id->qp = NULL;
 	}
-	ep->conn_setup->tgt_connected = 1;
 }
 
 /* Caller must hold the eq:lock */

--- a/prov/verbs/src/verbs_domain_xrc.c
+++ b/prov/verbs/src/verbs_domain_xrc.c
@@ -119,7 +119,6 @@ int fi_ibv_get_shared_ini_conn(struct fi_ibv_xrc_ep *ep,
 	struct fi_ibv_ini_shared_conn *conn;
 	struct ofi_rbnode *node;
 	int ret;
-	assert(ep->base_ep.id);
 
 	fi_ibv_set_ini_conn_key(ep, &key);
 	node = ofi_rbmap_find(domain->xrc.ini_conn_rbmap, &key);
@@ -243,6 +242,7 @@ void fi_ibv_sched_ini_conn(struct fi_ibv_ini_shared_conn *ini_conn)
 {
 	struct fi_ibv_xrc_ep *ep;
 	enum fi_ibv_ini_qp_state last_state;
+	struct sockaddr *peer_addr;
 	int ret;
 
 	/* Continue to schedule shared connections if the physical connection
@@ -260,6 +260,16 @@ void fi_ibv_sched_ini_conn(struct fi_ibv_ini_shared_conn *ini_conn)
 		dlist_insert_tail(&ep->ini_conn_entry,
 				  &ep->ini_conn->active_list);
 		last_state = ep->ini_conn->state;
+
+		/* TODO: Select RDMA_PS_TCP/UDP based on last_state (i.e. physical) */
+		ret = fi_ibv_create_ep(ep->base_ep.info, &ep->base_ep.id);
+		if (ret) {
+			VERBS_WARN(FI_LOG_EP_CTRL,
+				   "Failed to create active CM ID %d\n",
+				   ret);
+			goto err;
+		}
+
 		if (last_state == FI_IBV_INI_QP_UNCONNECTED) {
 			assert(!ep->ini_conn->phys_conn_id && ep->base_ep.id);
 
@@ -291,6 +301,23 @@ void fi_ibv_sched_ini_conn(struct fi_ibv_ini_shared_conn *ini_conn)
 		}
 
 		assert(ep->ini_conn->ini_qp);
+		ep->base_ep.id->context = &ep->base_ep.util_ep.ep_fid.fid;
+		ret = rdma_migrate_id(ep->base_ep.id,
+				      ep->base_ep.eq->channel);
+		if (ret) {
+			VERBS_WARN(FI_LOG_EP_CTRL,
+				   "Failed to migreate active CM ID %d\n", ret);
+			goto err;
+		}
+
+		peer_addr = rdma_get_local_addr(ep->base_ep.id);
+		if (peer_addr)
+			ofi_straddr_dbg(&fi_ibv_prov, FI_LOG_EP_CTRL,
+					"XRC connect src_addr", peer_addr);
+		peer_addr = rdma_get_peer_addr(ep->base_ep.id);
+		if (peer_addr)
+			ofi_straddr_dbg(&fi_ibv_prov, FI_LOG_EP_CTRL,
+					"XRC connect dest_addr", peer_addr);
 
 		ep->base_ep.ibv_qp = ep->ini_conn->ini_qp;
 		ret = fi_ibv_process_ini_conn(ep, ep->conn_setup->pending_recip,

--- a/prov/verbs/src/verbs_domain_xrc.c
+++ b/prov/verbs/src/verbs_domain_xrc.c
@@ -344,7 +344,7 @@ int fi_ibv_process_ini_conn(struct fi_ibv_xrc_ep *ep,int reciprocal,
 			       ep->conn_setup->remote_conn_tag :
 			       ep->conn_setup->conn_tag,
 			       ep->base_ep.eq->xrc.pep_port,
-			       ep->ini_conn->tgt_qpn);
+			       ep->ini_conn->tgt_qpn, ep->srqn);
 
 	ep->base_ep.conn_param.private_data = cm_data;
 	ep->base_ep.conn_param.private_data_len = paramlen;

--- a/prov/verbs/src/verbs_domain_xrc.c
+++ b/prov/verbs/src/verbs_domain_xrc.c
@@ -340,9 +340,12 @@ int fi_ibv_process_ini_conn(struct fi_ibv_xrc_ep *ep,int reciprocal,
 
 	assert(ep->base_ep.ibv_qp);
 
-	fi_ibv_set_xrc_cm_data(cm_data, reciprocal, ep->conn_setup->conn_tag,
+	fi_ibv_set_xrc_cm_data(cm_data, reciprocal, reciprocal ?
+			       ep->conn_setup->remote_conn_tag :
+			       ep->conn_setup->conn_tag,
 			       ep->base_ep.eq->xrc.pep_port,
 			       ep->ini_conn->tgt_qpn);
+
 	ep->base_ep.conn_param.private_data = cm_data;
 	ep->base_ep.conn_param.private_data_len = paramlen;
 	ep->base_ep.conn_param.responder_resources = RDMA_MAX_RESP_RES;

--- a/prov/verbs/src/verbs_domain_xrc.c
+++ b/prov/verbs/src/verbs_domain_xrc.c
@@ -458,9 +458,8 @@ static int fi_ibv_put_tgt_qp(struct fi_ibv_xrc_ep *ep)
 /* Caller must hold eq:lock */
 int fi_ibv_ep_destroy_xrc_qp(struct fi_ibv_xrc_ep *ep)
 {
-	if (ep->base_ep.ibv_qp) {
-		fi_ibv_put_shared_ini_conn(ep);
-	}
+	fi_ibv_put_shared_ini_conn(ep);
+
 	if (ep->base_ep.id) {
 		rdma_destroy_id(ep->base_ep.id);
 		ep->base_ep.id = NULL;

--- a/prov/verbs/src/verbs_domain_xrc.c
+++ b/prov/verbs/src/verbs_domain_xrc.c
@@ -262,7 +262,8 @@ void fi_ibv_sched_ini_conn(struct fi_ibv_ini_shared_conn *ini_conn)
 		last_state = ep->ini_conn->state;
 
 		/* TODO: Select RDMA_PS_TCP/UDP based on last_state (i.e. physical) */
-		ret = fi_ibv_create_ep(ep->base_ep.info, &ep->base_ep.id);
+		ret = fi_ibv_create_ep(ep->base_ep.info, RDMA_PS_TCP,
+				       &ep->base_ep.id);
 		if (ret) {
 			VERBS_WARN(FI_LOG_EP_CTRL,
 				   "Failed to create active CM ID %d\n",

--- a/prov/verbs/src/verbs_domain_xrc.c
+++ b/prov/verbs/src/verbs_domain_xrc.c
@@ -225,14 +225,17 @@ void fi_ibv_add_pending_ini_conn(struct fi_ibv_xrc_ep *ep, int reciprocal,
 	dlist_insert_tail(&ep->ini_conn_entry, &ep->ini_conn->pending_list);
 }
 
+/* Caller must hold domain:eq:lock */
 static void fi_ibv_create_shutdown_event(struct fi_ibv_xrc_ep *ep)
 {
 	struct fi_eq_cm_entry entry = {
 		.fid = &ep->base_ep.util_ep.ep_fid.fid,
 	};
+	struct fi_ibv_eq_entry *eq_entry;
 
-	fi_ibv_eq_write_event(ep->base_ep.eq, FI_SHUTDOWN,
-			      &entry, sizeof(entry));
+	eq_entry = fi_ibv_eq_alloc_entry(FI_SHUTDOWN, &entry, sizeof(entry));
+	if (eq_entry)
+		dlistfd_insert_tail(&eq_entry->item, &ep->base_ep.eq->list_head);
 }
 
 /* Caller must hold domain:eq:lock */

--- a/prov/verbs/src/verbs_ep.c
+++ b/prov/verbs/src/verbs_ep.c
@@ -332,14 +332,15 @@ static int fi_ibv_ep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 
 			/* Make sure EQ channel is not polled during migrate */
 			fastlock_acquire(&ep->eq->lock);
-			ret = rdma_migrate_id(ep->id, ep->eq->channel);
-			if (ret)  {
-				fastlock_release(&ep->eq->lock);
-				return -errno;
-			}
 			if (fi_ibv_is_xrc(ep->info)) {
 				ret = fi_ibv_ep_xrc_set_tgt_chan(ep);
 				if (ret) {
+					fastlock_release(&ep->eq->lock);
+					return -errno;
+				}
+			} else {
+				ret = rdma_migrate_id(ep->id, ep->eq->channel);
+				if (ret)  {
 					fastlock_release(&ep->eq->lock);
 					return -errno;
 				}
@@ -882,9 +883,13 @@ int fi_ibv_open_ep(struct fid_domain *domain, struct fi_info *info,
 		}
 
 		if (!info->handle) {
-			ret = fi_ibv_create_ep(info, &ep->id);
-			if (ret)
-				goto err1;
+			/* Only RC, XRC active RDMA CM ID is created at connect */
+			if (!(dom->flags & VRB_USE_XRC)) {
+				ret = fi_ibv_create_ep(info, &ep->id);
+				if (ret)
+					goto err1;
+				ep->id->context = &ep->util_ep.ep_fid.fid;
+			}
 		} else if (info->handle->fclass == FI_CLASS_CONNREQ) {
 			connreq = container_of(info->handle,
 					       struct fi_ibv_connreq, handle);
@@ -900,6 +905,7 @@ int fi_ibv_open_ep(struct fid_domain *domain, struct fi_info *info,
 			} else {
 				ep->id = connreq->id;
 				ep->ibv_qp = ep->id->qp;
+				ep->id->context = &ep->util_ep.ep_fid.fid;
 			}
 		} else if (info->handle->fclass == FI_CLASS_PEP) {
 			pep = container_of(info->handle, struct fi_ibv_pep, pep_fid.fid);
@@ -913,11 +919,11 @@ int fi_ibv_open_ep(struct fid_domain *domain, struct fi_info *info,
 				VERBS_INFO(FI_LOG_DOMAIN, "Unable to rdma_resolve_addr\n");
 				goto err2;
 			}
+			ep->id->context = &ep->util_ep.ep_fid.fid;
 		} else {
 			ret = -FI_ENOSYS;
 			goto err1;
 		}
-		ep->id->context = &ep->util_ep.ep_fid.fid;
 		break;
 	case FI_EP_DGRAM:
 		ep->service = (info->src_addr) ?
@@ -948,7 +954,8 @@ int fi_ibv_open_ep(struct fid_domain *domain, struct fi_info *info,
 	return FI_SUCCESS;
 err2:
 	ep->ibv_qp = NULL;
-	rdma_destroy_ep(ep->id);
+	if (ep->id)
+		rdma_destroy_ep(ep->id);
 err1:
 	fi_ibv_close_free_ep(ep);
 	return ret;

--- a/prov/verbs/src/verbs_ep.c
+++ b/prov/verbs/src/verbs_ep.c
@@ -885,7 +885,8 @@ int fi_ibv_open_ep(struct fid_domain *domain, struct fi_info *info,
 		if (!info->handle) {
 			/* Only RC, XRC active RDMA CM ID is created at connect */
 			if (!(dom->flags & VRB_USE_XRC)) {
-				ret = fi_ibv_create_ep(info, &ep->id);
+				ret = fi_ibv_create_ep(info, RDMA_PS_TCP,
+						       &ep->id);
 				if (ret)
 					goto err1;
 				ep->id->context = &ep->util_ep.ep_fid.fid;

--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -551,7 +551,8 @@ fi_ibv_eq_xrc_cm_err_event(struct fi_ibv_eq *eq,
 static inline int
 fi_ibv_eq_xrc_connected_event(struct fi_ibv_eq *eq,
 			      struct rdma_cm_event *cma_event,
-			      struct fi_eq_cm_entry *entry, size_t len)
+			      struct fi_eq_cm_entry *entry, size_t len,
+			      int *acked)
 {
 	struct fi_ibv_xrc_ep *ep;
 	fid_t fid = cma_event->id->context;
@@ -567,9 +568,10 @@ fi_ibv_eq_xrc_connected_event(struct fi_ibv_eq *eq,
 
 	ret = fi_ibv_eq_xrc_recip_conn_event(eq, ep, cma_event, entry, len);
 
-	/* Bidirectional connection setup is complete, release RDMA CM ID resources.
-	 * Note this will initiate release of shared QP reservation/hardware resources
-	 * that were needed for XRC shared connection setup as well. */
+	/* Bidirectional connection setup is complete, release RDMA CM ID
+	 * resources. */
+	rdma_ack_cm_event(cma_event);
+	*acked = 1;
 	fi_ibv_free_xrc_conn_setup(ep, 1);
 
 	return ret;
@@ -589,19 +591,11 @@ fi_ibv_eq_xrc_timewait_event(struct fi_ibv_eq *eq,
 	if (cma_event->id == ep->tgt_id) {
 		*acked = 1;
 		rdma_ack_cm_event(cma_event);
-		if (ep->conn_setup->rsvd_tgt_qpn) {
-			ibv_destroy_qp(ep->conn_setup->rsvd_tgt_qpn);
-			ep->conn_setup->rsvd_tgt_qpn = NULL;
-		}
 		rdma_destroy_id(ep->tgt_id);
 		ep->tgt_id = NULL;
 	} else if (cma_event->id == ep->base_ep.id) {
 		*acked = 1;
 		rdma_ack_cm_event(cma_event);
-		if (ep->conn_setup->rsvd_ini_qpn) {
-			ibv_destroy_qp(ep->conn_setup->rsvd_ini_qpn);
-			ep->conn_setup->rsvd_ini_qpn = NULL;
-		}
 		rdma_destroy_id(ep->base_ep.id);
 		ep->base_ep.id = NULL;
 	}
@@ -694,7 +688,7 @@ fi_ibv_eq_cm_process_event(struct fi_ibv_eq *eq,
 		ep = container_of(fid, struct fi_ibv_ep, util_ep.ep_fid);
 		if (fi_ibv_is_xrc(ep->info)) {
 			ret = fi_ibv_eq_xrc_connected_event(eq, cma_event,
-							    entry, len);
+							    entry, len, &acked);
 			goto ack;
 		}
 		entry->info = NULL;

--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -285,16 +285,55 @@ static void fi_ibv_eq_skip_xrc_cm_data(const void **priv_data,
 }
 
 static int
+fi_ibv_eq_accept_recip_conn(struct fi_ibv_xrc_ep *ep,
+			    struct fi_eq_cm_entry *entry, size_t len,
+			    uint32_t *event, struct rdma_cm_event *cma_event,
+			    int *acked)
+{
+	struct fi_ibv_xrc_cm_data cm_data;
+	int ret;
+
+	assert(ep->conn_state == FI_IBV_XRC_ORIG_CONNECTED);
+
+	ret = fi_ibv_accept_xrc(ep, FI_IBV_RECIP_CONN, &cm_data,
+				sizeof(cm_data));
+	if (ret) {
+		VERBS_WARN(FI_LOG_EP_CTRL,
+			   "Reciprocal XRC Accept failed %d\n", ret);
+		return ret;
+	}
+
+	/* SIDR based shared reciprocal connections are complete at
+	 * this point, generate the connection established event. */
+	if (ep->tgt_id->ps == RDMA_PS_UDP) {
+		fi_ibv_next_xrc_conn_state(ep);
+		fi_ibv_ep_tgt_conn_done(ep);
+		entry->fid = &ep->base_ep.util_ep.ep_fid.fid;
+		*event = FI_CONNECTED;
+		len = fi_ibv_eq_copy_event_data(entry, len,
+						ep->conn_setup->event_data,
+						ep->conn_setup->event_len);
+		*acked = 1;
+		rdma_ack_cm_event(cma_event);
+		fi_ibv_free_xrc_conn_setup(ep, 1);
+
+		return sizeof(*entry) + len;
+	}
+
+	/* Event is handled internally and not passed to the application */
+	return -FI_EAGAIN;
+}
+
+static int
 fi_ibv_eq_xrc_connreq_event(struct fi_ibv_eq *eq, struct fi_eq_cm_entry *entry,
 			    size_t len, uint32_t *event,
+			    struct rdma_cm_event *cma_event, int *acked,
 			    const void **priv_data, size_t *priv_datalen)
 {
 	struct fi_ibv_connreq *connreq = container_of(entry->info->handle,
 						struct fi_ibv_connreq, handle);
 	struct fi_ibv_xrc_ep *ep;
-	struct fi_ibv_xrc_cm_data cm_data;
 	int ret;
-	enum rdma_port_space ps;
 
 	if (!connreq->xrc.is_reciprocal) {
 		fi_ibv_eq_skip_xrc_cm_data(priv_data, priv_datalen);
@@ -313,7 +352,10 @@ fi_ibv_eq_xrc_connreq_event(struct fi_ibv_eq *eq, struct fi_eq_cm_entry *entry,
 			   connreq->xrc.conn_tag);
 		return -FI_EAGAIN;
 	}
-	assert(ep->conn_state == FI_IBV_XRC_ORIG_CONNECTED);
+	ep->recip_req_received = 1;
+
+	assert(ep->conn_state == FI_IBV_XRC_ORIG_CONNECTED ||
+	       ep->conn_state == FI_IBV_XRC_ORIG_CONNECTING);
 
 	ep->tgt_id = connreq->id;
 	ep->tgt_id->context = &ep->base_ep.util_ep.ep_fid.fid;
@@ -325,29 +367,12 @@ fi_ibv_eq_xrc_connreq_event(struct fi_ibv_eq *eq, struct fi_eq_cm_entry *entry,
 		goto send_reject;
 	}
 
-	ps = ep->tgt_id->ps;
-	ret = fi_ibv_accept_xrc(ep, FI_IBV_RECIP_CONN, &cm_data,
-				sizeof(cm_data));
-	if (ret) {
-		VERBS_WARN(FI_LOG_EP_CTRL,
-			   "Reciprocal XRC Accept failed %d\n", ret);
-		goto send_reject;
-	}
+	/* If the initial connection has completed proceed with accepting
+	 * the reciprocal; otherwise wait until it has before proceeding */
+	if (ep->conn_state == FI_IBV_XRC_ORIG_CONNECTED)
+		return fi_ibv_eq_accept_recip_conn(ep, entry, len, event,
+						   cma_event, acked);
 
-	/* SIDR based shared reciprocal connections are complete at
-	 * this point, generate the connection established event. */
-	if (ps == RDMA_PS_UDP) {
-		fi_ibv_next_xrc_conn_state(ep);
-		fi_ibv_ep_tgt_conn_done(ep);
-		entry->fid = &ep->base_ep.util_ep.ep_fid.fid;
-		*event = FI_CONNECTED;
-		len = fi_ibv_eq_copy_event_data(entry, len,
-						ep->conn_setup->event_data,
-						ep->conn_setup->event_len);
-		return sizeof(*entry) + len;
-	}
-
-	/* Event is handled internally and not passed to the application */
 	return -FI_EAGAIN;
 
 send_reject:
@@ -369,8 +394,9 @@ fi_ibv_eq_xrc_establish(struct rdma_cm_event *cma_event)
 
 static int
 fi_ibv_eq_xrc_conn_event(struct fi_ibv_xrc_ep *ep,
-			 struct rdma_cm_event *cma_event,
-			 struct fi_eq_cm_entry *entry)
+			 struct rdma_cm_event *cma_event, int *acked,
+			 struct fi_eq_cm_entry *entry, size_t len,
+			 uint32_t *event)
 {
 	struct fi_ibv_xrc_conn_info xrc_info;
 	struct fi_ibv_xrc_cm_data cm_data;
@@ -400,6 +426,13 @@ fi_ibv_eq_xrc_conn_event(struct fi_ibv_xrc_ep *ep,
 		fi_ibv_ep_ini_conn_done(ep, xrc_info.conn_data,
 					xrc_info.conn_param.qp_num);
 		fi_ibv_eq_xrc_establish(cma_event);
+
+		/* If we have received the reciprocal connect request,
+		 * process it now */
+		if (ep->recip_req_received)
+			return fi_ibv_eq_accept_recip_conn(ep, entry,
+							   len, event,
+							   cma_event, acked);
 	} else {
 		fi_ibv_ep_tgt_conn_done(ep);
 		ret = fi_ibv_connect_xrc(ep, NULL, FI_IBV_RECIP_CONN, &cm_data,
@@ -549,9 +582,9 @@ fi_ibv_eq_xrc_cm_err_event(struct fi_ibv_eq *eq,
 /* Caller must hold eq:lock */
 static inline int
 fi_ibv_eq_xrc_connected_event(struct fi_ibv_eq *eq,
-			      struct rdma_cm_event *cma_event,
+			      struct rdma_cm_event *cma_event, int *acked,
 			      struct fi_eq_cm_entry *entry, size_t len,
-			      int *acked)
+			      uint32_t *event)
 {
 	struct fi_ibv_xrc_ep *ep;
 	fid_t fid = cma_event->id->context;
@@ -563,14 +596,15 @@ fi_ibv_eq_xrc_connected_event(struct fi_ibv_eq *eq,
 	       ep->conn_state == FI_IBV_XRC_RECIP_CONNECTING);
 
 	if (ep->conn_state == FI_IBV_XRC_ORIG_CONNECTING)
-		return fi_ibv_eq_xrc_conn_event(ep, cma_event, entry);
+		return fi_ibv_eq_xrc_conn_event(ep, cma_event, acked,
+						entry, len, event);
 
 	ret = fi_ibv_eq_xrc_recip_conn_event(eq, ep, cma_event, entry, len);
 
 	/* Bidirectional connection setup is complete, release RDMA CM ID
 	 * resources. */
-	rdma_ack_cm_event(cma_event);
 	*acked = 1;
+	rdma_ack_cm_event(cma_event);
 	fi_ibv_free_xrc_conn_setup(ep, 1);
 
 	return ret;
@@ -668,6 +702,7 @@ fi_ibv_eq_cm_process_event(struct fi_ibv_eq *eq,
 
 		if (fi_ibv_is_xrc(entry->info)) {
 			ret = fi_ibv_eq_xrc_connreq_event(eq, entry, len, event,
+							  cma_event, &acked,
 							  &priv_data, &priv_datalen);
 			if (ret == -FI_EAGAIN || *event == FI_CONNECTED)
 				goto ack;
@@ -687,7 +722,8 @@ fi_ibv_eq_cm_process_event(struct fi_ibv_eq *eq,
 		ep = container_of(fid, struct fi_ibv_ep, util_ep.ep_fid);
 		if (fi_ibv_is_xrc(ep->info)) {
 			ret = fi_ibv_eq_xrc_connected_event(eq, cma_event,
-							    entry, len, &acked);
+							    &acked, entry, len,
+							    event);
 			goto ack;
 		}
 		entry->info = NULL;

--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -78,7 +78,6 @@ void fi_ibv_eq_set_xrc_conn_tag(struct fi_ibv_xrc_ep *ep)
 	ep->conn_setup->conn_tag =
 		(uint32_t)ofi_idx2key(&eq->xrc.conn_key_idx,
 				ofi_idx_insert(eq->xrc.conn_key_map, ep));
-	ep->conn_setup->created_conn_tag = true;
 }
 
 /* Caller must hold eq:lock */
@@ -88,7 +87,7 @@ void fi_ibv_eq_clear_xrc_conn_tag(struct fi_ibv_xrc_ep *ep)
 	int index;
 
 	assert(ep->conn_setup);
-	if (!ep->conn_setup->created_conn_tag)
+	if (ep->conn_setup->conn_tag == VERBS_CONN_TAG_INVALID)
 		return;
 
 	index = ofi_key2idx(&eq->xrc.conn_key_idx,

--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -287,6 +287,7 @@ static void fi_ibv_eq_skip_xrc_cm_data(const void **priv_data,
 
 static int
 fi_ibv_eq_xrc_connreq_event(struct fi_ibv_eq *eq, struct fi_eq_cm_entry *entry,
+			    size_t len, uint32_t *event,
 			    const void **priv_data, size_t *priv_datalen)
 {
 	struct fi_ibv_connreq *connreq = container_of(entry->info->handle,
@@ -294,6 +295,7 @@ fi_ibv_eq_xrc_connreq_event(struct fi_ibv_eq *eq, struct fi_eq_cm_entry *entry,
 	struct fi_ibv_xrc_ep *ep;
 	struct fi_ibv_xrc_cm_data cm_data;
 	int ret;
+	enum rdma_port_space ps;
 
 	if (!connreq->xrc.is_reciprocal) {
 		fi_ibv_eq_skip_xrc_cm_data(priv_data, priv_datalen);
@@ -310,7 +312,7 @@ fi_ibv_eq_xrc_connreq_event(struct fi_ibv_eq *eq, struct fi_eq_cm_entry *entry,
 		VERBS_WARN(FI_LOG_EP_CTRL,
 			   "Reciprocal XRC connection tag 0x%x not found\n",
 			   connreq->xrc.conn_tag);
-		goto done;
+		return -FI_EAGAIN;
 	}
 	assert(ep->conn_state == FI_IBV_XRC_ORIG_CONNECTED);
 
@@ -324,6 +326,7 @@ fi_ibv_eq_xrc_connreq_event(struct fi_ibv_eq *eq, struct fi_eq_cm_entry *entry,
 		goto send_reject;
 	}
 
+	ps = ep->tgt_id->ps;
 	ret = fi_ibv_accept_xrc(ep, FI_IBV_RECIP_CONN, &cm_data,
 				sizeof(cm_data));
 	if (ret) {
@@ -331,7 +334,19 @@ fi_ibv_eq_xrc_connreq_event(struct fi_ibv_eq *eq, struct fi_eq_cm_entry *entry,
 			   "Reciprocal XRC Accept failed %d\n", ret);
 		goto send_reject;
 	}
-done:
+
+	/* SIDR based shared reciprocal connections are complete at
+	 * this point, generate the connection established event. */
+	if (ps == RDMA_PS_UDP) {
+		fi_ibv_next_xrc_conn_state(ep);
+		fi_ibv_ep_tgt_conn_done(ep);
+		entry->fid = &ep->base_ep.util_ep.ep_fid.fid;
+		*event = FI_CONNECTED;
+		len = fi_ibv_eq_copy_event_data(entry, len,
+						ep->conn_setup->event_data,
+						ep->conn_setup->event_len);
+		return sizeof(*entry) + len;
+	}
 
 	/* Event is handled internally and not passed to the application */
 	return -FI_EAGAIN;
@@ -364,8 +379,8 @@ fi_ibv_eq_xrc_conn_event(struct fi_ibv_xrc_ep *ep,
 	size_t priv_datalen = cma_event->param.conn.private_data_len;
 	int ret;
 
-	VERBS_DBG(FI_LOG_EP_CTRL, "EP %p INITIAL CONNECTION DONE state %d\n",
-		  ep, ep->conn_state);
+	VERBS_DBG(FI_LOG_EP_CTRL, "EP %p INITIAL CONNECTION DONE state %d, ps %d\n",
+		  ep, ep->conn_state, cma_event->id->ps);
 	fi_ibv_next_xrc_conn_state(ep);
 
 	/*
@@ -474,7 +489,8 @@ fi_ibv_eq_xrc_rej_event(struct fi_ibv_eq *eq, struct rdma_cm_event *cma_event)
 	}
 
 	/* If reject comes from remote provider peer */
-	if (cma_event->status == FI_IBV_CM_REJ_CONSUMER_DEFINED) {
+	if (cma_event->status == FI_IBV_CM_REJ_CONSUMER_DEFINED ||
+	    cma_event->status == FI_IBV_CM_REJ_SIDR_CONSUMER_DEFINED) {
 		if (cma_event->param.conn.private_data_len &&
 		    fi_ibv_eq_set_xrc_info(cma_event, &xrc_info)) {
 			VERBS_WARN(FI_LOG_EP_CTRL,
@@ -496,7 +512,7 @@ fi_ibv_eq_xrc_rej_event(struct fi_ibv_eq *eq, struct rdma_cm_event *cma_event)
 	return state == FI_IBV_XRC_ORIG_CONNECTING ? FI_SUCCESS : -FI_EAGAIN;
 }
 
-/* Caller must hold eq:lock */                                                                                  
+/* Caller must hold eq:lock */
 static inline int
 fi_ibv_eq_xrc_cm_err_event(struct fi_ibv_eq *eq,
                            struct rdma_cm_event *cma_event)
@@ -627,11 +643,6 @@ fi_ibv_eq_cm_process_event(struct fi_ibv_eq *eq,
 	struct fi_ibv_ep *ep;
 	struct fi_ibv_xrc_ep *xrc_ep;
 
-	if (cma_event->id->ps == RDMA_PS_UDP) {
-		VERBS_DBG(FI_LOG_EQ, "PS_UDP not supported\n");
-		return -FI_EAGAIN;
-	}
-
 	switch (cma_event->event) {
 	case RDMA_CM_EVENT_ROUTE_RESOLVED:
 		ep = container_of(fid, struct fi_ibv_ep, util_ep.ep_fid);
@@ -663,9 +674,9 @@ fi_ibv_eq_cm_process_event(struct fi_ibv_eq *eq,
 		}
 
 		if (fi_ibv_is_xrc(entry->info)) {
-			ret = fi_ibv_eq_xrc_connreq_event(eq, entry, &priv_data,
-							  &priv_datalen);
-			if (ret == -FI_EAGAIN)
+			ret = fi_ibv_eq_xrc_connreq_event(eq, entry, len, event,
+							  &priv_data, &priv_datalen);
+			if (ret == -FI_EAGAIN || *event == FI_CONNECTED)
 				goto ack;
 		}
 		break;
@@ -711,6 +722,11 @@ fi_ibv_eq_cm_process_event(struct fi_ibv_eq *eq,
 		ep = container_of(fid, struct fi_ibv_ep, util_ep.ep_fid);
 		assert(ep->info);
 		if (fi_ibv_is_xrc(ep->info)) {
+			/* SIDR Reject is reported as UNREACHABLE */
+			if (cma_event->id->ps == RDMA_PS_UDP &&
+			    cma_event->event == RDMA_CM_EVENT_UNREACHABLE)
+				goto xrc_shared_reject;
+
 			ret = fi_ibv_eq_xrc_cm_err_event(eq, cma_event);
 			if (ret == -FI_EAGAIN)
 				goto ack;
@@ -726,6 +742,7 @@ fi_ibv_eq_cm_process_event(struct fi_ibv_eq *eq,
 	case RDMA_CM_EVENT_REJECTED:
 		ep = container_of(fid, struct fi_ibv_ep, util_ep.ep_fid);
 		if (fi_ibv_is_xrc(ep->info)) {
+xrc_shared_reject:
 			ret = fi_ibv_eq_xrc_rej_event(eq, cma_event);
 			if (ret == -FI_EAGAIN)
 				goto ack;

--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -649,7 +649,6 @@ fi_ibv_eq_xrc_disconnect_event(struct fi_ibv_eq *eq,
 		*acked = 1;
 		rdma_ack_cm_event(cma_event);
 		rdma_disconnect(ep->base_ep.id);
-		ep->conn_setup->ini_connected = 0;
 	}
 }
 

--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -627,6 +627,11 @@ fi_ibv_eq_cm_process_event(struct fi_ibv_eq *eq,
 	struct fi_ibv_ep *ep;
 	struct fi_ibv_xrc_ep *xrc_ep;
 
+	if (cma_event->id->ps == RDMA_PS_UDP) {
+		VERBS_DBG(FI_LOG_EQ, "PS_UDP not supported\n");
+		return -FI_EAGAIN;
+	}
+
 	switch (cma_event->event) {
 	case RDMA_CM_EVENT_ROUTE_RESOLVED:
 		ep = container_of(fid, struct fi_ibv_ep, util_ep.ep_fid);

--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -144,7 +144,8 @@ static int fi_ibv_eq_set_xrc_info(struct rdma_cm_event *event,
 	info->is_reciprocal = remote->reciprocal;
 	info->conn_tag = ntohl(remote->conn_tag);
 	info->port = ntohs(remote->port);
-	info->conn_data = ntohl(remote->param);
+	info->tgt_qpn = ntohl(remote->tgt_qpn);
+	info->peer_srqn = ntohl(remote->srqn);
 	info->conn_param = event->param.conn;
 	info->conn_param.private_data = NULL;
 	info->conn_param.private_data_len = 0;
@@ -420,11 +421,10 @@ fi_ibv_eq_xrc_conn_event(struct fi_ibv_xrc_ep *ep,
 			rdma_disconnect(ep->base_ep.id);
 			goto err;
 		}
-		ep->peer_srqn = xrc_info.conn_data;
+		ep->peer_srqn = xrc_info.peer_srqn;
 		fi_ibv_eq_skip_xrc_cm_data(&priv_data, &priv_datalen);
 		fi_ibv_save_priv_data(ep, priv_data, priv_datalen);
-		fi_ibv_ep_ini_conn_done(ep, xrc_info.conn_data,
-					xrc_info.conn_param.qp_num);
+		fi_ibv_ep_ini_conn_done(ep, xrc_info.conn_param.qp_num);
 		fi_ibv_eq_xrc_establish(cma_event);
 
 		/* If we have received the reciprocal connect request,
@@ -476,9 +476,8 @@ fi_ibv_eq_xrc_recip_conn_event(struct fi_ibv_eq *eq,
 			return -FI_EAVAIL;
 		}
 
-		ep->peer_srqn = xrc_info.conn_data;
-		fi_ibv_ep_ini_conn_done(ep, xrc_info.conn_data,
-					xrc_info.conn_param.qp_num);
+		ep->peer_srqn = xrc_info.peer_srqn;
+		fi_ibv_ep_ini_conn_done(ep, xrc_info.conn_param.qp_num);
 		fi_ibv_eq_xrc_establish(cma_event);
 	} else {
 		fi_ibv_ep_tgt_conn_done(ep);

--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -806,20 +806,32 @@ void fi_ibv_eq_remove_events(struct fi_ibv_eq *eq, struct fid *fid)
 	}
 }
 
-ssize_t fi_ibv_eq_write_event(struct fi_ibv_eq *eq, uint32_t event,
-			      const void *buf, size_t len)
+struct fi_ibv_eq_entry  *
+fi_ibv_eq_alloc_entry(uint32_t event, const void *buf, size_t len)
 {
 	struct fi_ibv_eq_entry *entry;
 
 	entry = calloc(1, sizeof(struct fi_ibv_eq_entry) + len);
 	if (!entry) {
 		VERBS_WARN(FI_LOG_EP_CTRL, "Unable to allocate EQ entry\n");
-		return -FI_ENOMEM;
+		return NULL;
 	}
 
 	entry->event = event;
 	entry->len = len;
 	memcpy(entry->entry, buf, len);
+
+	return entry;
+}
+
+ssize_t fi_ibv_eq_write_event(struct fi_ibv_eq *eq, uint32_t event,
+			      const void *buf, size_t len)
+{
+	struct fi_ibv_eq_entry *entry;
+
+	entry = fi_ibv_eq_alloc_entry(event, buf, len);
+	if (!entry)
+		return -FI_ENOMEM;
 
 	fastlock_acquire(&eq->lock);
 	dlistfd_insert_tail(&entry->item, &eq->list_head);


### PR DESCRIPTION
This is a series of patches that implement using RDMA CM SIDR message exchanges to setup virtual/shared XRC QP connections. This avoids the necessity of creating temporary hardware resources when setting up the shared connections.  With these changes XRC connection setup becomes faster than RC when the PPN count is greater than 4 PPN, and is up to 70% faster than the existing XRC connection setup implementation.