### PR TITLE
contrib/cray: Update IMB parameters

### DIFF
--- a/contrib/cray/Jenkinsfile.verbs
+++ b/contrib/cray/Jenkinsfile.verbs
@@ -323,7 +323,7 @@ pipeline {
                             }
                         }
                         tee ('imb.tap') {
-                            timeout(time: 10, unit: 'MINUTES') {
+                            timeout(time: 20, unit: 'MINUTES') {
                                 sh '${BATS_INSTALL_PATH}/bats -t contrib/cray/bats/imb.bats'
 			    }
 			}

--- a/contrib/cray/bats/batsgenerator.sh
+++ b/contrib/cray/bats/batsgenerator.sh
@@ -3,7 +3,7 @@
 # Assumes IMB test suite has been installed and included in Jenkinsfile.verbs file
 # Example:
 # Add IMB-EXT Windows test running 20 ranks, 5 ranks per node to imb.bats
-#       ./batsgenerator.sh imb_EXT windows 20 5 imb.bats
+#       ./batsgenerator.sh IMB-EXT windows 20 5 imb.bats
 
 # Insert shebang and load test helper
 shebang="#!/usr/bin/env bats\n\n"

--- a/contrib/cray/bats/benchmark.template
+++ b/contrib/cray/bats/benchmark.template
@@ -1,13 +1,13 @@
 # RC                                                                                                                                     
 @test "@TEST_SUITE@ @BENCHMARK@ @RANKS@ ranks, @RPN@ ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher @RANKS@ @RPN@) timeout 300 "$IMB_BUILD_PATH/@TEST_SUITE@ @BENCHMARK@"
+                $(batch_launcher @RANKS@ @RPN@) timeout 300 "$IMB_BUILD_PATH/@TEST_SUITE@ -npmin @RANKS@ -iter 100 -time 10 -mem 2 -msglog 2:18 @BENCHMARK@"
         [ "$status" -eq 0 ]
 }
 
 # XRC
 @test "@TEST_SUITE@ @BENCHMARK@ @RANKS@ ranks, @RPN@ ranks per node using XRC verbs" {
         FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher @RANKS@ @RPN@) timeout 300 "$IMB_BUILD_PATH/@TEST_SUITE@ @BENCHMARK@"
+                $(batch_launcher @RANKS@ @RPN@) timeout 300 "$IMB_BUILD_PATH/@TEST_SUITE@ -npmin @RANKS@ -iter 100 -time 10 -mem 2 -msglog 2:18 @BENCHMARK@"
         [ "$status" -eq 0 ]
 }

--- a/contrib/cray/bats/imb.bats
+++ b/contrib/cray/bats/imb.bats
@@ -5,624 +5,611 @@ load test_helper
 # RC                                                                                                                                     
 @test "IMB-P2P unirandom 2 ranks, 1 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 2 1) timeout 300 "$IMB_BUILD_PATH/IMB-P2P unirandom"
+                $(batch_launcher 2 1) timeout 300 "$IMB_BUILD_PATH/IMB-P2P -npmin 2 -time 10 -mem 2 -msglog 2:18 unirandom"
         [ "$status" -eq 0 ]
 }
 
 # XRC
 @test "IMB-P2P unirandom 2 ranks, 1 ranks per node using XRC verbs" {
         FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 2 1) timeout 300 "$IMB_BUILD_PATH/IMB-P2P unirandom"
+                $(batch_launcher 2 1) timeout 300 "$IMB_BUILD_PATH/IMB-P2P -npmin 2 -time 10 -mem 2 -msglog 2:18 unirandom"
         [ "$status" -eq 0 ]
 }
 # RC                                                                                                                                     
 @test "IMB-P2P birandom 2 ranks, 1 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 2 1) timeout 300 "$IMB_BUILD_PATH/IMB-P2P birandom"
+                $(batch_launcher 2 1) timeout 300 "$IMB_BUILD_PATH/IMB-P2P -npmin 2 -time 10 -mem 2 -msglog 2:18 birandom"
         [ "$status" -eq 0 ]
 }
 
 # XRC
 @test "IMB-P2P birandom 2 ranks, 1 ranks per node using XRC verbs" {
         FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 2 1) timeout 300 "$IMB_BUILD_PATH/IMB-P2P birandom"
+                $(batch_launcher 2 1) timeout 300 "$IMB_BUILD_PATH/IMB-P2P -npmin 2 -time 10 -mem 2 -msglog 2:18 birandom"
         [ "$status" -eq 0 ]
 }
 # RC                                                                                                                                     
 @test "IMB-P2P corandom 2 ranks, 1 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 2 1) timeout 300 "$IMB_BUILD_PATH/IMB-P2P corandom"
+                $(batch_launcher 2 1) timeout 300 "$IMB_BUILD_PATH/IMB-P2P -npmin 2 -time 10 -mem 2 -msglog 2:18 corandom"
         [ "$status" -eq 0 ]
 }
 
 # XRC
 @test "IMB-P2P corandom 2 ranks, 1 ranks per node using XRC verbs" {
         FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 2 1) timeout 300 "$IMB_BUILD_PATH/IMB-P2P corandom"
-        [ "$status" -eq 0 ]
-}
-# RC                                                                                                                                     
-@test "IMB-EXT window 20 ranks, 5 ranks per node using RC verbs" {
-        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-EXT window"
-        [ "$status" -eq 0 ]
-}
-
-# XRC
-@test "IMB-EXT window 20 ranks, 5 ranks per node using XRC verbs" {
-        FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-EXT window"
-        [ "$status" -eq 0 ]
-}
-# RC                                                                                                                                     
-@test "IMB-EXT accumulate 20 ranks, 5 ranks per node using RC verbs" {
-        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-EXT accumulate"
-        [ "$status" -eq 0 ]
-}
-
-# XRC
-@test "IMB-EXT accumulate 20 ranks, 5 ranks per node using XRC verbs" {
-        FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-EXT accumulate"
+                $(batch_launcher 2 1) timeout 300 "$IMB_BUILD_PATH/IMB-P2P -npmin 2 -time 10 -mem 2 -msglog 2:18 corandom"
         [ "$status" -eq 0 ]
 }
 # RC                                                                                                                                     
 @test "IMB-RMA bidir_get 2 ranks, 1 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 2 1) timeout 300 "$IMB_BUILD_PATH/IMB-RMA bidir_get"
+                $(batch_launcher 2 1) timeout 300 "$IMB_BUILD_PATH/IMB-RMA -npmin 2 -time 10 -mem 2 -msglog 2:18 bidir_get"
         [ "$status" -eq 0 ]
 }
 
 # XRC
 @test "IMB-RMA bidir_get 2 ranks, 1 ranks per node using XRC verbs" {
         FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 2 1) timeout 300 "$IMB_BUILD_PATH/IMB-RMA bidir_get"
+                $(batch_launcher 2 1) timeout 300 "$IMB_BUILD_PATH/IMB-RMA -npmin 2 -time 10 -mem 2 -msglog 2:18 bidir_get"
         [ "$status" -eq 0 ]
 }
 # RC                                                                                                                                     
 @test "IMB-RMA bidir_put 2 ranks, 1 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 2 1) timeout 300 "$IMB_BUILD_PATH/IMB-RMA bidir_put"
+                $(batch_launcher 2 1) timeout 300 "$IMB_BUILD_PATH/IMB-RMA -npmin 2 -time 10 -mem 2 -msglog 2:18 bidir_put"
         [ "$status" -eq 0 ]
 }
 
 # XRC
 @test "IMB-RMA bidir_put 2 ranks, 1 ranks per node using XRC verbs" {
         FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 2 1) timeout 300 "$IMB_BUILD_PATH/IMB-RMA bidir_put"
+                $(batch_launcher 2 1) timeout 300 "$IMB_BUILD_PATH/IMB-RMA -npmin 2 -time 10 -mem 2 -msglog 2:18 bidir_put"
         [ "$status" -eq 0 ]
 }
 # RC                                                                                                                                     
 @test "IMB-RMA unidir_get 2 ranks, 1 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 2 1) timeout 300 "$IMB_BUILD_PATH/IMB-RMA unidir_get"
+                $(batch_launcher 2 1) timeout 300 "$IMB_BUILD_PATH/IMB-RMA -npmin 2 -time 10 -mem 2 -msglog 2:18 unidir_get"
         [ "$status" -eq 0 ]
 }
 
 # XRC
 @test "IMB-RMA unidir_get 2 ranks, 1 ranks per node using XRC verbs" {
         FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 2 1) timeout 300 "$IMB_BUILD_PATH/IMB-RMA unidir_get"
+                $(batch_launcher 2 1) timeout 300 "$IMB_BUILD_PATH/IMB-RMA -npmin 2 -time 10 -mem 2 -msglog 2:18 unidir_get"
         [ "$status" -eq 0 ]
 }
 # RC                                                                                                                                     
 @test "IMB-RMA unidir_put 2 ranks, 1 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 2 1) timeout 300 "$IMB_BUILD_PATH/IMB-RMA unidir_put"
+                $(batch_launcher 2 1) timeout 300 "$IMB_BUILD_PATH/IMB-RMA -npmin 2 -time 10 -mem 2 -msglog 2:18 unidir_put"
         [ "$status" -eq 0 ]
 }
 
 # XRC
 @test "IMB-RMA unidir_put 2 ranks, 1 ranks per node using XRC verbs" {
         FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 2 1) timeout 300 "$IMB_BUILD_PATH/IMB-RMA unidir_put"
+                $(batch_launcher 2 1) timeout 300 "$IMB_BUILD_PATH/IMB-RMA -npmin 2 -time 10 -mem 2 -msglog 2:18 unidir_put"
         [ "$status" -eq 0 ]
 }
 # RC                                                                                                                                     
-@test "IMB-NBC iallgather 40 ranks, 10 ranks per node using RC verbs" {
+@test "IMB-EXT window 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-NBC iallgather"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-EXT -npmin 20 -time 10 -mem 2 -msglog 2:18 window"
         [ "$status" -eq 0 ]
 }
 
 # XRC
-@test "IMB-NBC iallgather 40 ranks, 10 ranks per node using XRC verbs" {
+@test "IMB-EXT window 20 ranks, 5 ranks per node using XRC verbs" {
         FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-NBC iallgather"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-EXT -npmin 20 -time 10 -mem 2 -msglog 2:18 window"
         [ "$status" -eq 0 ]
 }
 # RC                                                                                                                                     
-@test "IMB-NBC iallgather_pure 40 ranks, 10 ranks per node using RC verbs" {
+@test "IMB-EXT accumulate 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-NBC iallgather_pure"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-EXT -npmin 20 -time 10 -mem 2 -msglog 2:18 accumulate"
         [ "$status" -eq 0 ]
 }
 
 # XRC
-@test "IMB-NBC iallgather_pure 40 ranks, 10 ranks per node using XRC verbs" {
+@test "IMB-EXT accumulate 20 ranks, 5 ranks per node using XRC verbs" {
         FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-NBC iallgather_pure"
-        [ "$status" -eq 0 ]
-}
-# RC                                                                                                                                     
-@test "IMB-NBC iallgatherv 40 ranks, 10 ranks per node using RC verbs" {
-        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-NBC iallgatherv"
-        [ "$status" -eq 0 ]
-}
-
-# XRC
-@test "IMB-NBC iallgatherv 40 ranks, 10 ranks per node using XRC verbs" {
-        FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-NBC iallgatherv"
-        [ "$status" -eq 0 ]
-}
-# RC                                                                                                                                     
-@test "IMB-NBC iallgatherv_pure 40 ranks, 10 ranks per node using RC verbs" {
-        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-NBC iallgatherv_pure"
-        [ "$status" -eq 0 ]
-}
-
-# XRC
-@test "IMB-NBC iallgatherv_pure 40 ranks, 10 ranks per node using XRC verbs" {
-        FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-NBC iallgatherv_pure"
-        [ "$status" -eq 0 ]
-}
-# RC                                                                                                                                     
-@test "IMB-NBC iallreduce 40 ranks, 10 ranks per node using RC verbs" {
-        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-NBC iallreduce"
-        [ "$status" -eq 0 ]
-}
-
-# XRC
-@test "IMB-NBC iallreduce 40 ranks, 10 ranks per node using XRC verbs" {
-        FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-NBC iallreduce"
-        [ "$status" -eq 0 ]
-}
-# RC                                                                                                                                     
-@test "IMB-NBC iallreduce_pure 40 ranks, 10 ranks per node using RC verbs" {
-        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-NBC iallreduce_pure"
-        [ "$status" -eq 0 ]
-}
-
-# XRC
-@test "IMB-NBC iallreduce_pure 40 ranks, 10 ranks per node using XRC verbs" {
-        FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-NBC iallreduce_pure"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-EXT -npmin 20 -time 10 -mem 2 -msglog 2:18 accumulate"
         [ "$status" -eq 0 ]
 }
 # RC                                                                                                                                     
 @test "IMB-NBC ialltoall 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC ialltoall"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 ialltoall"
         [ "$status" -eq 0 ]
 }
 
 # XRC
 @test "IMB-NBC ialltoall 20 ranks, 5 ranks per node using XRC verbs" {
         FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC ialltoall"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 ialltoall"
         [ "$status" -eq 0 ]
 }
 # RC                                                                                                                                     
 @test "IMB-NBC ialltoall_pure 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC ialltoall_pure"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 ialltoall_pure"
         [ "$status" -eq 0 ]
 }
 
 # XRC
 @test "IMB-NBC ialltoall_pure 20 ranks, 5 ranks per node using XRC verbs" {
         FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC ialltoall_pure"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 ialltoall_pure"
         [ "$status" -eq 0 ]
 }
 # RC                                                                                                                                     
 @test "IMB-NBC ialltoallv 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC ialltoallv"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 ialltoallv"
         [ "$status" -eq 0 ]
 }
 
 # XRC
 @test "IMB-NBC ialltoallv 20 ranks, 5 ranks per node using XRC verbs" {
         FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC ialltoallv"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 ialltoallv"
         [ "$status" -eq 0 ]
 }
 # RC                                                                                                                                     
 @test "IMB-NBC ialltoallv_pure 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC ialltoallv_pure"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 ialltoallv_pure"
         [ "$status" -eq 0 ]
 }
 
 # XRC
 @test "IMB-NBC ialltoallv_pure 20 ranks, 5 ranks per node using XRC verbs" {
         FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC ialltoallv_pure"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 ialltoallv_pure"
         [ "$status" -eq 0 ]
 }
 # RC                                                                                                                                     
-@test "IMB-NBC ibarrier 40 ranks, 10 ranks per node using RC verbs" {
+@test "IMB-NBC iallgather 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-NBC ibarrier"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 iallgather"
         [ "$status" -eq 0 ]
 }
 
 # XRC
-@test "IMB-NBC ibarrier 40 ranks, 10 ranks per node using XRC verbs" {
+@test "IMB-NBC iallgather 20 ranks, 5 ranks per node using XRC verbs" {
         FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-NBC ibarrier"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 iallgather"
         [ "$status" -eq 0 ]
 }
 # RC                                                                                                                                     
-@test "IMB-NBC ibarrier_pure 40 ranks, 10 ranks per node using RC verbs" {
+@test "IMB-NBC iallgather_pure 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-NBC ibarrier_pure"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 iallgather_pure"
         [ "$status" -eq 0 ]
 }
 
 # XRC
-@test "IMB-NBC ibarrier_pure 40 ranks, 10 ranks per node using XRC verbs" {
+@test "IMB-NBC iallgather_pure 20 ranks, 5 ranks per node using XRC verbs" {
         FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-NBC ibarrier_pure"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 iallgather_pure"
         [ "$status" -eq 0 ]
 }
 # RC                                                                                                                                     
-@test "IMB-NBC ibcast 40 ranks, 10 ranks per node using RC verbs" {
+@test "IMB-NBC iallgatherv 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-NBC ibcast"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 iallgatherv"
         [ "$status" -eq 0 ]
 }
 
 # XRC
-@test "IMB-NBC ibcast 40 ranks, 10 ranks per node using XRC verbs" {
+@test "IMB-NBC iallgatherv 20 ranks, 5 ranks per node using XRC verbs" {
         FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-NBC ibcast"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 iallgatherv"
         [ "$status" -eq 0 ]
 }
 # RC                                                                                                                                     
-@test "IMB-NBC ibcast_pure 40 ranks, 10 ranks per node using RC verbs" {
+@test "IMB-NBC iallgatherv_pure 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-NBC ibcast_pure"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 iallgatherv_pure"
         [ "$status" -eq 0 ]
 }
 
 # XRC
-@test "IMB-NBC ibcast_pure 40 ranks, 10 ranks per node using XRC verbs" {
+@test "IMB-NBC iallgatherv_pure 20 ranks, 5 ranks per node using XRC verbs" {
         FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-NBC ibcast_pure"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 iallgatherv_pure"
         [ "$status" -eq 0 ]
 }
 # RC                                                                                                                                     
-@test "IMB-NBC igather 40 ranks, 10 ranks per node using RC verbs" {
+@test "IMB-NBC iallreduce 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-NBC igather"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 iallreduce"
         [ "$status" -eq 0 ]
 }
 
 # XRC
-@test "IMB-NBC igather 40 ranks, 10 ranks per node using XRC verbs" {
+@test "IMB-NBC iallreduce 20 ranks, 5 ranks per node using XRC verbs" {
         FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-NBC igather"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 iallreduce"
         [ "$status" -eq 0 ]
 }
 # RC                                                                                                                                     
-@test "IMB-NBC igather_pure 40 ranks, 10 ranks per node using RC verbs" {
+@test "IMB-NBC iallreduce_pure 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-NBC igather_pure"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 iallreduce_pure"
         [ "$status" -eq 0 ]
 }
 
 # XRC
-@test "IMB-NBC igather_pure 40 ranks, 10 ranks per node using XRC verbs" {
+@test "IMB-NBC iallreduce_pure 20 ranks, 5 ranks per node using XRC verbs" {
         FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-NBC igather_pure"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 iallreduce_pure"
         [ "$status" -eq 0 ]
 }
 # RC                                                                                                                                     
-@test "IMB-NBC igatherv 40 ranks, 10 ranks per node using RC verbs" {
+@test "IMB-NBC ibarrier 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-NBC igatherv"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 ibarrier"
         [ "$status" -eq 0 ]
 }
 
 # XRC
-@test "IMB-NBC igatherv 40 ranks, 10 ranks per node using XRC verbs" {
+@test "IMB-NBC ibarrier 20 ranks, 5 ranks per node using XRC verbs" {
         FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-NBC igatherv"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 ibarrier"
         [ "$status" -eq 0 ]
 }
 # RC                                                                                                                                     
-@test "IMB-NBC igatherv_pure 40 ranks, 10 ranks per node using RC verbs" {
+@test "IMB-NBC ibarrier_pure 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-NBC igatherv_pure"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 ibarrier_pure"
         [ "$status" -eq 0 ]
 }
 
 # XRC
-@test "IMB-NBC igatherv_pure 40 ranks, 10 ranks per node using XRC verbs" {
+@test "IMB-NBC ibarrier_pure 20 ranks, 5 ranks per node using XRC verbs" {
         FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-NBC igatherv_pure"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 ibarrier_pure"
         [ "$status" -eq 0 ]
 }
 # RC                                                                                                                                     
-@test "IMB-NBC ireduce 40 ranks, 10 ranks per node using RC verbs" {
+@test "IMB-NBC ibcast 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-NBC ireduce"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 ibcast"
         [ "$status" -eq 0 ]
 }
 
 # XRC
-@test "IMB-NBC ireduce 40 ranks, 10 ranks per node using XRC verbs" {
+@test "IMB-NBC ibcast 20 ranks, 5 ranks per node using XRC verbs" {
         FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-NBC ireduce"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 ibcast"
         [ "$status" -eq 0 ]
 }
 # RC                                                                                                                                     
-@test "IMB-NBC ireduce_pure 40 ranks, 10 ranks per node using RC verbs" {
+@test "IMB-NBC ibcast_pure 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-NBC ireduce_pure"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 ibcast_pure"
         [ "$status" -eq 0 ]
 }
 
 # XRC
-@test "IMB-NBC ireduce_pure 40 ranks, 10 ranks per node using XRC verbs" {
+@test "IMB-NBC ibcast_pure 20 ranks, 5 ranks per node using XRC verbs" {
         FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-NBC ireduce_pure"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 ibcast_pure"
         [ "$status" -eq 0 ]
 }
 # RC                                                                                                                                     
-@test "IMB-NBC ireduce_scatter 40 ranks, 10 ranks per node using RC verbs" {
+@test "IMB-NBC igather 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-NBC ireduce_scatter"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 igather"
         [ "$status" -eq 0 ]
 }
 
 # XRC
-@test "IMB-NBC ireduce_scatter 40 ranks, 10 ranks per node using XRC verbs" {
+@test "IMB-NBC igather 20 ranks, 5 ranks per node using XRC verbs" {
         FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-NBC ireduce_scatter"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 igather"
         [ "$status" -eq 0 ]
 }
 # RC                                                                                                                                     
-@test "IMB-NBC ireduce_scatter_pure 40 ranks, 10 ranks per node using RC verbs" {
+@test "IMB-NBC igather_pure 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-NBC ireduce_scatter_pure"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 igather_pure"
         [ "$status" -eq 0 ]
 }
 
 # XRC
-@test "IMB-NBC ireduce_scatter_pure 40 ranks, 10 ranks per node using XRC verbs" {
+@test "IMB-NBC igather_pure 20 ranks, 5 ranks per node using XRC verbs" {
         FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-NBC ireduce_scatter_pure"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 igather_pure"
         [ "$status" -eq 0 ]
 }
 # RC                                                                                                                                     
-@test "IMB-NBC iscatter 40 ranks, 10 ranks per node using RC verbs" {
+@test "IMB-NBC igatherv 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-NBC iscatter"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 igatherv"
         [ "$status" -eq 0 ]
 }
 
 # XRC
-@test "IMB-NBC iscatter 40 ranks, 10 ranks per node using XRC verbs" {
+@test "IMB-NBC igatherv 20 ranks, 5 ranks per node using XRC verbs" {
         FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-NBC iscatter"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 igatherv"
         [ "$status" -eq 0 ]
 }
 # RC                                                                                                                                     
-@test "IMB-NBC iscatter_pure 40 ranks, 10 ranks per node using RC verbs" {
+@test "IMB-NBC igatherv_pure 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-NBC iscatter_pure"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 igatherv_pure"
         [ "$status" -eq 0 ]
 }
 
 # XRC
-@test "IMB-NBC iscatter_pure 40 ranks, 10 ranks per node using XRC verbs" {
+@test "IMB-NBC igatherv_pure 20 ranks, 5 ranks per node using XRC verbs" {
         FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-NBC iscatter_pure"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 igatherv_pure"
         [ "$status" -eq 0 ]
 }
 # RC                                                                                                                                     
-@test "IMB-NBC iscatterv 40 ranks, 10 ranks per node using RC verbs" {
+@test "IMB-NBC ireduce 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-NBC iscatterv"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 ireduce"
         [ "$status" -eq 0 ]
 }
 
 # XRC
-@test "IMB-NBC iscatterv 40 ranks, 10 ranks per node using XRC verbs" {
+@test "IMB-NBC ireduce 20 ranks, 5 ranks per node using XRC verbs" {
         FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-NBC iscatterv"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 ireduce"
         [ "$status" -eq 0 ]
 }
 # RC                                                                                                                                     
-@test "IMB-NBC iscatterv_pure 40 ranks, 10 ranks per node using RC verbs" {
+@test "IMB-NBC ireduce_pure 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-NBC iscatterv_pure"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 ireduce_pure"
         [ "$status" -eq 0 ]
 }
 
 # XRC
-@test "IMB-NBC iscatterv_pure 40 ranks, 10 ranks per node using XRC verbs" {
+@test "IMB-NBC ireduce_pure 20 ranks, 5 ranks per node using XRC verbs" {
         FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-NBC iscatterv_pure"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 ireduce_pure"
         [ "$status" -eq 0 ]
 }
 # RC                                                                                                                                     
-@test "IMB-MPI1 reduce 40 ranks, 10 ranks per node using RC verbs" {
+@test "IMB-NBC ireduce_scatter 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 reduce"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 ireduce_scatter"
         [ "$status" -eq 0 ]
 }
 
 # XRC
-@test "IMB-MPI1 reduce 40 ranks, 10 ranks per node using XRC verbs" {
+@test "IMB-NBC ireduce_scatter 20 ranks, 5 ranks per node using XRC verbs" {
         FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 reduce"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 ireduce_scatter"
         [ "$status" -eq 0 ]
 }
 # RC                                                                                                                                     
-@test "IMB-MPI1 reduce_scatter 40 ranks, 10 ranks per node using RC verbs" {
+@test "IMB-NBC iscatter 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 reduce_scatter"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 iscatter"
         [ "$status" -eq 0 ]
 }
 
 # XRC
-@test "IMB-MPI1 reduce_scatter 40 ranks, 10 ranks per node using XRC verbs" {
+@test "IMB-NBC iscatter 20 ranks, 5 ranks per node using XRC verbs" {
         FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 reduce_scatter"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 iscatter"
         [ "$status" -eq 0 ]
 }
 # RC                                                                                                                                     
-@test "IMB-MPI1 reduce_scatter_block 40 ranks, 10 ranks per node using RC verbs" {
+@test "IMB-NBC iscatter_pure 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 reduce_scatter_block"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 iscatter_pure"
         [ "$status" -eq 0 ]
 }
 
 # XRC
-@test "IMB-MPI1 reduce_scatter_block 40 ranks, 10 ranks per node using XRC verbs" {
+@test "IMB-NBC iscatter_pure 20 ranks, 5 ranks per node using XRC verbs" {
         FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 reduce_scatter_block"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 iscatter_pure"
         [ "$status" -eq 0 ]
 }
 # RC                                                                                                                                     
-@test "IMB-MPI1 allreduce 40 ranks, 10 ranks per node using RC verbs" {
+@test "IMB-NBC iscatterv 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 allreduce"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 iscatterv"
         [ "$status" -eq 0 ]
 }
 
 # XRC
-@test "IMB-MPI1 allreduce 40 ranks, 10 ranks per node using XRC verbs" {
+@test "IMB-NBC iscatterv 20 ranks, 5 ranks per node using XRC verbs" {
         FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 allreduce"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 iscatterv"
         [ "$status" -eq 0 ]
 }
 # RC                                                                                                                                     
-@test "IMB-MPI1 allgather 40 ranks, 10 ranks per node using RC verbs" {
+@test "IMB-NBC iscatterv_pure 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 allgather"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 iscatterv_pure"
         [ "$status" -eq 0 ]
 }
 
 # XRC
-@test "IMB-MPI1 allgather 40 ranks, 10 ranks per node using XRC verbs" {
+@test "IMB-NBC iscatterv_pure 20 ranks, 5 ranks per node using XRC verbs" {
         FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 allgather"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 iscatterv_pure"
         [ "$status" -eq 0 ]
 }
 # RC                                                                                                                                     
-@test "IMB-MPI1 allgatherv 40 ranks, 10 ranks per node using RC verbs" {
+@test "IMB-MPI1 reduce 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 allgatherv"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 reduce"
         [ "$status" -eq 0 ]
 }
 
 # XRC
-@test "IMB-MPI1 allgatherv 40 ranks, 10 ranks per node using XRC verbs" {
+@test "IMB-MPI1 reduce 20 ranks, 5 ranks per node using XRC verbs" {
         FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 allgatherv"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 reduce"
         [ "$status" -eq 0 ]
 }
 # RC                                                                                                                                     
-@test "IMB-MPI1 scatter 40 ranks, 10 ranks per node using RC verbs" {
+@test "IMB-MPI1 reduce_scatter 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 scatter"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 reduce_scatter"
         [ "$status" -eq 0 ]
 }
 
 # XRC
-@test "IMB-MPI1 scatter 40 ranks, 10 ranks per node using XRC verbs" {
+@test "IMB-MPI1 reduce_scatter 20 ranks, 5 ranks per node using XRC verbs" {
         FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 scatter"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 reduce_scatter"
         [ "$status" -eq 0 ]
 }
 # RC                                                                                                                                     
-@test "IMB-MPI1 scatterv 40 ranks, 10 ranks per node using RC verbs" {
+@test "IMB-MPI1 reduce_scatter_block 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 scatterv"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 reduce_scatter_block"
         [ "$status" -eq 0 ]
 }
 
 # XRC
-@test "IMB-MPI1 scatterv 40 ranks, 10 ranks per node using XRC verbs" {
+@test "IMB-MPI1 reduce_scatter_block 20 ranks, 5 ranks per node using XRC verbs" {
         FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 scatterv"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 reduce_scatter_block"
         [ "$status" -eq 0 ]
 }
 # RC                                                                                                                                     
-@test "IMB-MPI1 gather 40 ranks, 10 ranks per node using RC verbs" {
+@test "IMB-MPI1 allreduce 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 gather"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 allreduce"
         [ "$status" -eq 0 ]
 }
 
 # XRC
-@test "IMB-MPI1 gather 40 ranks, 10 ranks per node using XRC verbs" {
+@test "IMB-MPI1 allreduce 20 ranks, 5 ranks per node using XRC verbs" {
         FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 gather"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 allreduce"
         [ "$status" -eq 0 ]
 }
 # RC                                                                                                                                     
-@test "IMB-MPI1 gatherv 40 ranks, 10 ranks per node using RC verbs" {
+@test "IMB-MPI1 allgather 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 gatherv"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 allgather"
         [ "$status" -eq 0 ]
 }
 
 # XRC
-@test "IMB-MPI1 gatherv 40 ranks, 10 ranks per node using XRC verbs" {
+@test "IMB-MPI1 allgather 20 ranks, 5 ranks per node using XRC verbs" {
         FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 gatherv"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 allgather"
+        [ "$status" -eq 0 ]
+}
+# RC                                                                                                                                     
+@test "IMB-MPI1 allgatherv 20 ranks, 5 ranks per node using RC verbs" {
+        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 allgatherv"
+        [ "$status" -eq 0 ]
+}
+
+# XRC
+@test "IMB-MPI1 allgatherv 20 ranks, 5 ranks per node using XRC verbs" {
+        FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 allgatherv"
+        [ "$status" -eq 0 ]
+}
+# RC                                                                                                                                     
+@test "IMB-MPI1 scatter 20 ranks, 5 ranks per node using RC verbs" {
+        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 scatter"
+        [ "$status" -eq 0 ]
+}
+
+# XRC
+@test "IMB-MPI1 scatter 20 ranks, 5 ranks per node using XRC verbs" {
+        FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 scatter"
+        [ "$status" -eq 0 ]
+}
+# RC                                                                                                                                     
+@test "IMB-MPI1 scatterv 20 ranks, 5 ranks per node using RC verbs" {
+        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 scatterv"
+        [ "$status" -eq 0 ]
+}
+
+# XRC
+@test "IMB-MPI1 scatterv 20 ranks, 5 ranks per node using XRC verbs" {
+        FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 scatterv"
+        [ "$status" -eq 0 ]
+}
+# RC                                                                                                                                     
+@test "IMB-MPI1 gather 20 ranks, 5 ranks per node using RC verbs" {
+        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 gather"
+        [ "$status" -eq 0 ]
+}
+
+# XRC
+@test "IMB-MPI1 gather 20 ranks, 5 ranks per node using XRC verbs" {
+        FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 gather"
+        [ "$status" -eq 0 ]
+}
+# RC                                                                                                                                     
+@test "IMB-MPI1 gatherv 20 ranks, 5 ranks per node using RC verbs" {
+        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 gatherv"
+        [ "$status" -eq 0 ]
+}
+
+# XRC
+@test "IMB-MPI1 gatherv 20 ranks, 5 ranks per node using XRC verbs" {
+        FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 gatherv"
         [ "$status" -eq 0 ]
 }
 # RC                                                                                                                                     
 @test "IMB-MPI1 alltoall 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 alltoall"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 alltoall"
         [ "$status" -eq 0 ]
 }
 
 # XRC
 @test "IMB-MPI1 alltoall 20 ranks, 5 ranks per node using XRC verbs" {
         FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 alltoall"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 alltoall"
         [ "$status" -eq 0 ]
 }
 # RC                                                                                                                                     
-@test "IMB-MPI1 bcast 40 ranks, 10 ranks per node using RC verbs" {
+@test "IMB-MPI1 bcast 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 bcast"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 bcast"
         [ "$status" -eq 0 ]
 }
 
 # XRC
-@test "IMB-MPI1 bcast 40 ranks, 10 ranks per node using XRC verbs" {
+@test "IMB-MPI1 bcast 20 ranks, 5 ranks per node using XRC verbs" {
         FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 bcast"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 bcast"
         [ "$status" -eq 0 ]
 }
 # RC                                                                                                                                     
-@test "IMB-MPI1 barrier 40 ranks, 10 ranks per node using RC verbs" {
+@test "IMB-MPI1 barrier 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 barrier"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 barrier"
         [ "$status" -eq 0 ]
 }
 
 # XRC
-@test "IMB-MPI1 barrier 40 ranks, 10 ranks per node using XRC verbs" {
+@test "IMB-MPI1 barrier 20 ranks, 5 ranks per node using XRC verbs" {
         FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher 40 10) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 barrier"
+                $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 barrier"
         [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
Included additional parameters constraining IMB tests to minimize amount of time test takes. Additionally extended applications timeout cutoff in Jenkinsfile.verbs file to avoid timeout failure.

Signed-off-by: Leena Radeke <leena.radeke@hpe.com>