### PR TITLE
prov/verbs: Modify ibv_query_gid() to use FI_VERBS_GID_IDX environment variable

### DIFF
--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -793,7 +793,7 @@ static int vrb_alloc_info(struct ibv_context *ctx, struct fi_info **info,
 
 	switch (ctx->device->transport_type) {
 	case IBV_TRANSPORT_IB:
-		if (ibv_query_gid(ctx, 1, 0, &gid)) {
+		if (ibv_query_gid(ctx, 1, vrb_gl_data.gid_idx, &gid)) {
 			VERBS_INFO_ERRNO(FI_LOG_FABRIC,
 					 "ibv_query_gid", errno);
 			ret = -errno;


### PR DESCRIPTION
The verbs provider was originally calling ibv_query_gid() using a GID index hardcoded to 0. Modified to use a GID index provided by the FI_VERBS_GID_IDX environment variable.

Signed-off-by: Leena Radeke <leena.radeke@hpe.com>